### PR TITLE
autoload org-noter-start-from-dired from org-noter.el

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -1975,20 +1975,6 @@ See `org-noter-notes-window-behavior' for more information."
               (org-entry-put nil org-noter--property-doc-split-fraction (format "%s" new-setting))
             (org-entry-delete nil org-noter--property-doc-split-fraction))))))))
 
-(defun org-noter-start-from-dired ()
-  "In Dired, open sessions for marked files or file at point.
-
-If there are multiple marked files, focus will be on the last
-marked file."
-  (interactive)
-  (let ((files (or (dired-get-marked-files)
-                   (dired-get-filename))))
-    (dolist (filename files)
-      (find-file filename)
-      (save-excursion (org-noter))
-      (bury-buffer))
-    (other-frame 1)))
-
 (defun org-noter-kill-session (&optional session)
   "Kill an `org-noter' session.
 

--- a/org-noter.el
+++ b/org-noter.el
@@ -276,6 +276,21 @@ notes file, even if it finds one."
                     (org-noter arg))
                   (throw 'break t)))))))))))
 
+;;;###autoload
+(defun org-noter-start-from-dired ()
+  "In Dired, open sessions for marked files or file at point.
+
+If there are multiple marked files, focus will be on the last
+marked file."
+  (interactive)
+  (let ((files (or (dired-get-marked-files)
+                   (dired-get-filename))))
+    (dolist (filename files)
+      (find-file filename)
+      (save-excursion (org-noter))
+      (bury-buffer))
+    (other-frame 1)))
+
 (provide 'org-noter)
 
 ;;; org-noter.el ends here


### PR DESCRIPTION
I was finding that in a fresh emacs session, `org-noter-start-from-dired` was not loaded, so nothing would happen.  Turns out that as a startup commnad, it needs to be autoloaded.

I moved it from `org-noter-core.el` to `org-noter.el` and gave it the `;;;###autoload` magic command.

Tested on my local MELPA instance and seems to work fine.