### PR TITLE
[ISSUE-9] Try to load packages before emitting a warning that a package is missing.

### DIFF
--- a/modules/org-noter-djvu.el
+++ b/modules/org-noter-djvu.el
@@ -28,7 +28,7 @@
 
 (condition-case nil
     (require 'djvu)
-  (error (message "ATTENTION: org-noter-djvu needs the package `djvu'.")))
+  (error (message "ATTENTION: org-noter-djvu needs the package `djvu'")))
 
 (defun org-noter-djvu--pretty-print-location (location)
   (org-noter--with-valid-session

--- a/modules/org-noter-djvu.el
+++ b/modules/org-noter-djvu.el
@@ -24,9 +24,11 @@
 
 ;;; Code:
 (require 'org-noter-core)
-(if (assq 'djvu package-alist)
+
+
+(condition-case nil
     (require 'djvu)
-  (message "ATTENTION: org-noter-dvju needs the package `djvu'."))
+  (error (message "ATTENTION: org-noter-djvu needs the package `djvu'.")))
 
 (defun org-noter-djvu--pretty-print-location (location)
   (org-noter--with-valid-session

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -27,7 +27,7 @@
 
 (condition-case nil
     (require 'nov)
-  (error (message "ATTENTION: org-noter-nov needs the package `nov'.")))
+  (error (message "ATTENTION: org-noter-nov needs the package `nov'")))
 
 (defvar nov-documents-index)
 (defvar nov-file-name)

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -24,9 +24,10 @@
 
 ;;; Code:
 (require 'org-noter-core)
-(if (assq 'nov package-alist)
+
+(condition-case nil
     (require 'nov)
-  (message "ATTENTION: org-noter-nov needs the package `nov'."))
+  (error (message "ATTENTION: org-noter-nov needs the package `nov'.")))
 
 (defvar nov-documents-index)
 (defvar nov-file-name)

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -29,7 +29,7 @@
 (condition-case nil
     (require 'pdf-tools)
     (require 'pdf-annot)
-    (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'.")))
+    (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'")))
 
 (cl-defstruct pdf-highlight page coords)
 

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -26,13 +26,12 @@
 (eval-when-compile (require 'subr-x))
 (require 'cl-lib)
 (require 'org-noter-core)
-(if (not (assq 'pdf-tools package-alist))
-    (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'.")
-  (require 'pdf-tools)
-  (require 'pdf-annot))
+(condition-case nil
+    (require 'pdf-tools)
+    (require 'pdf-annot)
+    (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'.")))
 
 (cl-defstruct pdf-highlight page coords)
-
 
 (defun org-noter-pdf--get-highlight ()
   "If there's an active pdf selection, returns a  that contains all


### PR DESCRIPTION
This fixes #9.

## Problem: 

Original code was targeting package.el; it doesn't work at all for `straight.el` so it would emit errors that weren't valid.


## Solution

Try to load the required package and only show an error if a package fails to load.


## Testing

I created a separate set of instructions for testing this [here](https://github.com/org-noter/org-noter-with-emacs-basic-test).



## Result

Previously org-noter would complain about pdf-tools, nov and djvu with the basic installed as described in testing you now get the following:

```
ATTENTION: org-noter-nov needs the package ‘nov’.
ATTENTION: org-noter-djvu needs the package ‘djvu’.
```
