### PR TITLE
bugfix: issue #12 (open document to saved location)

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -268,10 +268,12 @@ notes file, even if it finds one."
         (with-current-buffer (find-file-noselect (car notes-files-annotating))
           (org-with-point-at (point-min)
             (catch 'break
-              (while (re-search-forward (org-re-property org-noter-property-doc-file) nil t)
+              (while (re-search-forward (org-re-property org-noter-property-doc-file) nil)
                 (when (file-equal-p (expand-file-name (match-string 3)
                                                       (file-name-directory (car notes-files-annotating)))
                                     document-path)
+                  (if-let ((saved-location (org-entry-get nil org-noter-property-note-location)))
+                      (setq document-location (cons (string-to-number saved-location) 0)))
                   (let ((org-noter--start-location-override document-location))
                     (org-noter arg))
                   (throw 'break t)))))))))))

--- a/tests/Notes.org
+++ b/tests/Notes.org
@@ -403,6 +403,7 @@ i
 * MobyDick
   :PROPERTIES:
   :NOTER_DOCUMENT: MobyDick.pdf
+  :NOTER_PAGE: 171
   :END:
 ** Skeleton
     To time this code, you need the measure-time macro.


### PR DESCRIPTION
With this change, if the notes file for a document (tested for PDFs only) has a saved location in the top-level org entry, then upon starting the noter session, the document display is moved to that page.

Previously, this only worked when the session was started from the notes file.

Other minor changes:

1. `t` is not documented as a value for the optional 4th argument of `re-search-forward`.  Implicitly, it is acting as a `1`, but in the documentation `nil` (the default) makes the 4th argument (# of searches forward) `1`.  So the `t` is not needed.

2. Moby Dick in the "tests" subdir has as it's last saved location, page 171, the earlier of the two "Knights and Squires" chapters.