### PR TITLE
Add pdf-tools to Package-Requires

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -8,7 +8,7 @@
 ;;             Dmitry M <dmitrym@gmail.com>
 ;; Homepage: https://github.com/org-noter/org-noter
 ;; Keywords: lisp pdf interleave annotate external sync notes documents org-mode
-;; Package-Requires: ((emacs "24.4") (cl-lib "0.6") (org "9.0"))
+;; Package-Requires: ((emacs "24.4") (cl-lib "0.6") (org "9.0") (pdf-tools "0.90"))
 ;; Version: 1.5.0
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
This package is directly requiring `pdf-tools`, but doesn't specify it as a requirement in the `Package-Requires` specification. I didn't verify if any older version was possible, or if newer version would be required due to usage of newer functions. This is a quite old `pdf-tools` which was the version around the time this package was created. Another option would be to depend on the latest `pdf-tools` (1.0.0), but that is only half a year old.

I hope that someone that knows more about this package can correct this if it is wrong.

Thank you.