### PR TITLE
Maintenance/pdf modularization

### DIFF
--- a/modules/org-noter-djvu.el
+++ b/modules/org-noter-djvu.el
@@ -25,8 +25,11 @@
 ;;; Code:
 (require 'org-noter-core)
 
-
-(condition-case nil
+(eval-when-compile ; ensure that the compiled code knows about DJVU, if installed
+  (condition-case nil
+      (require 'djvu)
+    (error (message "`djvu' package not found"))))
+(condition-case nil ; run time warning
     (require 'djvu)
   (error (message "ATTENTION: org-noter-djvu needs the package `djvu'")))
 

--- a/modules/org-noter-djvu.el
+++ b/modules/org-noter-djvu.el
@@ -40,7 +40,7 @@
 (add-to-list 'org-noter--pretty-print-location-hook #'org-noter-djvu--pretty-print-location)
 (add-to-list 'org-noter--pretty-print-location-for-title-hook #'org-noter-djvu--pretty-print-location)
 
-(defun org-noter-djvu-approx-location-cons (mode &optional precise-info _force-new-ref)
+(defun org-noter-djvu--approx-location-cons (mode &optional precise-info _force-new-ref)
   (when (eq mode 'djvu-read-mode)
     (cons djvu-doc-page (if (or (numberp precise-info)
                                 (and (consp precise-info)
@@ -49,7 +49,7 @@
                             precise-info
                           (max 1 (/ (+ (window-start) (window-end nil t)) 2))))))
 
-(add-to-list 'org-noter--doc-approx-location-hook #'org-noter-djvu-approx-location-cons)
+(add-to-list 'org-noter--doc-approx-location-hook #'org-noter-djvu--approx-location-cons)
 
 (defun org-noter-djvu--get-precise-info (mode window)
   (when (eq mode 'djvu-read-mode)
@@ -63,14 +63,14 @@
 
 (add-to-list 'org-noter--get-precise-info-hook #'org-noter-djvu--get-precise-info)
 
-(defun org-noter-djvu-setup-handler (mode)
+(defun org-noter-djvu--setup-handler (mode)
   (when (eq mode 'djvu-read-mode)
     (advice-add 'djvu-init-page :after 'org-noter--location-change-advice)
     t))
 
-(add-to-list 'org-noter-set-up-document-hook #'org-noter-djvu-setup-handler)
+(add-to-list 'org-noter-set-up-document-hook #'org-noter-djvu--setup-handler)
 
-(defun org-noter-djvu-goto-location (mode location &optional window)
+(defun org-noter-djvu--goto-location (mode location &optional window)
   "DJVU mode function for `org-noter--doc-goto-location-hook'.
 MODE is the document mode and LOCATION is the note location.
 WINDOW is required by the hook, but not used in this function."
@@ -78,11 +78,11 @@ WINDOW is required by the hook, but not used in this function."
     (djvu-goto-page (car location))
     (goto-char (org-noter--get-location-top location))))
 
-(add-to-list 'org-noter--doc-goto-location-hook #'org-noter-djvu-goto-location)
+(add-to-list 'org-noter--doc-goto-location-hook #'org-noter-djvu--goto-location)
 
 (defun org-noter-djvu--get-current-view (mode)
   (when (eq mode 'djvu-read-mode)
-    (vector 'paged (car (org-noter-djvu-approx-location-cons mode)))))
+    (vector 'paged (car (org-noter-djvu--approx-location-cons mode)))))
 
 (add-to-list 'org-noter--get-current-view-hook #'org-noter-djvu--get-current-view)
 
@@ -93,7 +93,7 @@ WINDOW is required by the hook, but not used in this function."
 
 (add-to-list 'org-noter-get-selected-text-hook #'org-noter-djvu--get-selected-text)
 
-(defun org-noter-create-skeleton-djvu (mode)
+(defun org-noter-djvu--create-skeleton (mode)
   (when (eq mode 'djvu-read-mode)
     (org-noter--with-valid-session
      (let* ((ast (org-noter--parse-root))
@@ -146,7 +146,7 @@ WINDOW is required by the hook, but not used in this function."
            (org-show-children 2)))
        output-data))))
 
-(add-to-list 'org-noter-create-skeleton-functions #'org-noter-create-skeleton-djvu)
+(add-to-list 'org-noter-create-skeleton-functions #'org-noter-djvu--create-skeleton)
 
 (provide 'org-noter-djvu)
 ;;; org-noter-djvu.el ends here

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -32,12 +32,12 @@
 (defvar nov-documents-index)
 (defvar nov-file-name)
 
-(defun org-noter-get-buffer-file-name-nov (&optional mode)
+(defun org-noter-nov--get-buffer-file-name (&optional mode)
   (bound-and-true-p nov-file-name))
 
-(add-to-list 'org-noter-get-buffer-file-name-hook #'org-noter-get-buffer-file-name-nov)
+(add-to-list 'org-noter-get-buffer-file-name-hook #'org-noter-nov--get-buffer-file-name)
 
-(defun org-noter-nov-approx-location-cons (mode &optional precise-info _force-new-ref)
+(defun org-noter-nov--approx-location-cons (mode &optional precise-info _force-new-ref)
   (org-noter--with-valid-session
    (when (eq mode 'nov-mode)
      (cons nov-documents-index (if (or (numberp precise-info)
@@ -47,15 +47,15 @@
                                    precise-info
                                  (max 1 (/ (+ (window-start) (window-end nil t)) 2)))))))
 
-(add-to-list 'org-noter--doc-approx-location-hook #'org-noter-nov-approx-location-cons)
+(add-to-list 'org-noter--doc-approx-location-hook #'org-noter-nov--approx-location-cons)
 
-(defun org-noter-nov-setup-handler (mode)
+(defun org-noter-nov--setup-handler (mode)
   (when (eq mode 'nov-mode)
     (advice-add 'nov-render-document :after 'org-noter--nov-scroll-handler)
     (add-hook 'window-scroll-functions 'org-noter--nov-scroll-handler nil t)
     t))
 
-(add-to-list 'org-noter-set-up-document-hook #'org-noter-nov-setup-handler)
+(add-to-list 'org-noter-set-up-document-hook #'org-noter-nov--setup-handler)
 
 (defun org-noter-nov--pretty-print-location (location)
   (org-noter--with-valid-session
@@ -79,7 +79,7 @@
 
 (add-to-list 'org-noter--get-precise-info-hook #'org-noter-nov--get-precise-info)
 
-(defun org-noter-nov-goto-location (mode location &optional window)
+(defun org-noter-nov--goto-location (mode location &optional window)
   (when (eq mode 'nov-mode)
     (setq nov-documents-index (org-noter--get-location-page location))
     (nov-render-document)
@@ -88,13 +88,13 @@
     ;; everything and would run org-noter--nov-scroll-handler.
     (recenter)))
 
-(add-to-list 'org-noter--doc-goto-location-hook #'org-noter-nov-goto-location)
+(add-to-list 'org-noter--doc-goto-location-hook #'org-noter-nov--goto-location)
 
 (defun org-noter-nov--get-current-view (mode)
   (when (eq mode 'nov-mode)
     (vector 'nov
-            (org-noter-nov-approx-location-cons mode (window-start))
-            (org-noter-nov-approx-location-cons mode (window-end nil t)))))
+            (org-noter-nov--approx-location-cons mode (window-start))
+            (org-noter-nov--approx-location-cons mode (window-end nil t)))))
 
 (add-to-list 'org-noter--get-current-view-hook #'org-noter-nov--get-current-view)
 
@@ -109,7 +109,7 @@
 ;; This code is originally from org-noter-plus package.
 ;; At https://github.com/yuchen-lea/org-noter-plus
 
-(defun org-noter--handle-nov-toc-item (ol depth)
+(defun org-noter-nov--handle-toc-item (ol depth)
   (mapcar (lambda (li)
             (mapcar (lambda (a-or-ol)
                       (pcase-exhaustive (dom-tag a-or-ol)
@@ -118,12 +118,12 @@
                                  :title (dom-text a-or-ol)
                                  :href (esxml-node-attribute 'href a-or-ol)))
                         ('ol
-                         (org-noter--handle-nov-toc-item a-or-ol
+                         (org-noter-nov--handle-toc-item a-or-ol
                                                          (1+ depth)))))
                     (dom-children li)))
           (dom-children ol)))
 
-(defun org-noter-create-skeleton-epub (mode)
+(defun org-noter-nov--create-skeleton-epub (mode)
   "Epub outline with nov link."
   (when (eq mode 'nov-mode)
     (require 'esxml)
@@ -145,7 +145,7 @@
                 (origin-index nov-documents-index)
                 (origin-point (point)))
            (dolist (item
-                    (nreverse (flatten-tree (org-noter--handle-nov-toc-item toc-tree 1))))
+                    (nreverse (flatten-tree (org-noter-nov--handle-toc-item toc-tree 1))))
              (let ((relative-level  (aref item 1))
                    (title  (aref item 3))
                    (url (aref item 5)))
@@ -183,7 +183,7 @@
            (org-show-children 2)))
        output-data))))
 
-(add-to-list 'org-noter-create-skeleton-functions #'org-noter-create-skeleton-epub)
+(add-to-list 'org-noter-create-skeleton-functions #'org-noter-nov--create-skeleton-epub)
 
 (provide 'org-noter-nov)
 ;;; org-noter-nov.el ends here

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -25,7 +25,11 @@
 ;;; Code:
 (require 'org-noter-core)
 
-(condition-case nil
+(eval-when-compile ; ensure that the compiled code knows about NOV, if installed
+  (condition-case nil
+      (require 'nov)
+    (error (message "`nov' package not found"))))
+(condition-case nil ; run time warning
     (require 'nov)
   (error (message "ATTENTION: org-noter-nov needs the package `nov'")))
 

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -26,7 +26,11 @@
 (eval-when-compile (require 'subr-x))
 (require 'cl-lib)
 (require 'org-noter-core)
-(condition-case nil
+(eval-when-compile ; ensure that the compiled code knows about PDF-TOOLS, if installed
+  (condition-case nil
+      (require 'pdf-tools)
+    (error (message "`pdf-tools' package not found"))))
+(condition-case nil ; inform user at run time if pdf-tools is missing
     (require 'pdf-tools)
   (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'")))
 

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -65,7 +65,7 @@ PRECISE-INFO, return (page v-pos) or (page v-pos . h-pos)."
 
 (add-to-list 'org-noter--doc-approx-location-hook #'org-noter-pdf--approx-location-cons)
 
-(defun org-noter-pdf--get-buffer-file-name (&optional mode)
+(defun org-noter-pdf--get-buffer-file-name (&optional _mode)
   "Return the file naming backing the document buffer.
 
 MODE (unused) is required for this type of hook."

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -31,6 +31,16 @@
     (require 'pdf-annot)
     (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'")))
 
+(declare-function pdf-info-getannots "ext:pdf-info")
+(declare-function pdf-info-gettext "ext:pdf-info")
+(declare-function pdf-info-outline "ext:pdf-info")
+(declare-function pdf-info-pagelinks "ext:pdf-info")
+(declare-function pdf-view-active-region "ext:pdf-view")
+(declare-function pdf-view-active-region-p "ext:pdf-view")
+(declare-function pdf-view-active-region-text "ext:pdf-view")
+(declare-function pdf-view-goto-page "ext:pdf-view")
+(declare-function pdf-view-mode "ext:pdf-view")
+
 (cl-defstruct pdf-highlight page coords)
 
 (defun org-noter-pdf--get-highlight ()

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -33,16 +33,6 @@
 
 (require 'pdf-tools)
 
-(declare-function pdf-info-getannots "ext:pdf-info")
-(declare-function pdf-info-gettext "ext:pdf-info")
-(declare-function pdf-info-outline "ext:pdf-info")
-(declare-function pdf-info-pagelinks "ext:pdf-info")
-(declare-function pdf-view-active-region "ext:pdf-view")
-(declare-function pdf-view-active-region-p "ext:pdf-view")
-(declare-function pdf-view-active-region-text "ext:pdf-view")
-(declare-function pdf-view-goto-page "ext:pdf-view")
-(declare-function pdf-view-mode "ext:pdf-view")
-
 (cl-defstruct pdf-highlight page coords)
 
 (defun org-noter-pdf--get-highlight ()

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -31,6 +31,8 @@
     (require 'pdf-annot)
     (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'")))
 
+(require 'pdf-tools)
+
 (declare-function pdf-info-getannots "ext:pdf-info")
 (declare-function pdf-info-gettext "ext:pdf-info")
 (declare-function pdf-info-outline "ext:pdf-info")

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -28,10 +28,7 @@
 (require 'org-noter-core)
 (condition-case nil
     (require 'pdf-tools)
-    (require 'pdf-annot)
-    (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'")))
-
-(require 'pdf-tools)
+  (error (message "ATTENTION: org-noter-pdf has many featues that depend on the package `pdf-tools'")))
 
 (cl-defstruct pdf-highlight page coords)
 

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -516,6 +516,12 @@ Used by `org-noter--create-session' when creating a new session."
   :group 'org-noter-module-hooks
   :type 'hook)
 
+(defcustom org-noter--show-arrow-hook nil
+  "List of functions that show precise note location in document.
+For example, see `org-noter-pdf--show-arrow'."
+  :group 'org-noter-module-hooks
+  :type 'hook)
+
 ;; --------------------------------------------------------------------------------
 ;;; Private variables or constants
 (cl-defstruct org-noter--session
@@ -1257,51 +1263,7 @@ Scroll units are character-based."
   (when (and org-noter--arrow-location
              (window-live-p (aref org-noter--arrow-location 1)))
     (with-selected-window (aref org-noter--arrow-location 1)
-      ;; From `pdf-util-tooltip-arrow'.
-      (pdf-util-assert-pdf-window)
-      (let* (x-gtk-use-system-tooltips
-             (arrow-top  (aref org-noter--arrow-location 2)) ; % of page
-             (arrow-left (aref org-noter--arrow-location 3))
-             (image-top  (if (floatp arrow-top)
-                             (round (* arrow-top  (cdr (pdf-view-image-size)))))) ; pixel location on page (magnification-dependent)
-             (image-left (if (floatp arrow-left)
-                             (floor (* arrow-left (car (pdf-view-image-size))))))
-             (dx (or image-left
-                     (+ (or (car (window-margins)) 0)
-                        (car (window-fringes)))))
-             (dy (or image-top 0))
-             (pos (list dx dy dx (+ dy (* 2 (frame-char-height)))))
-             (vscroll (pdf-util-required-vscroll pos))
-             (tooltip-frame-parameters
-              `((border-width . 0)
-                (internal-border-width . 0)
-                ,@tooltip-frame-parameters))
-             (tooltip-hide-delay 3))
-
-        (when vscroll
-          (image-set-window-vscroll vscroll))
-        (setq dy (max 0 (- dy
-                           (cdr (pdf-view-image-offset))
-                           (window-vscroll nil t)
-                           (frame-char-height))))
-        (when (overlay-get (pdf-view-current-overlay) 'before-string)
-          (let* ((e (window-inside-pixel-edges))
-                 (xw (pdf-util-with-edges (e) e-width))
-                 (display-left-margin (/ (- xw (car (pdf-view-image-size t))) 2)))
-            (cl-incf dx display-left-margin)))
-        (setq dx (max 0 (+ dx org-noter-arrow-horizontal-offset)))
-        (pdf-util-tooltip-in-window
-         (propertize
-          " " 'display (propertize
-                        "\u2192" ;; right arrow
-                        'display '(height 2)
-                        'face `(:foreground
-                                ,org-noter-arrow-foreground-color
-                                :background
-                                ,(if (bound-and-true-p pdf-view-midnight-minor-mode)
-                                     (cdr pdf-view-midnight-colors)
-                                   org-noter-arrow-background-color))))
-         dx dy))
+      (run-hook-with-args-until-success 'org-noter--show-arrow-hook)
       (setq org-noter--arrow-location nil))))
 
 (defun org-noter--get-location-top (location)

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -23,7 +23,6 @@
 (require 'org)
 (require 'org-element)
 (require 'cl-lib)
-(require 'pdf-tools)
 
 (declare-function org-noter "org-noter")
 (declare-function doc-view-goto-page "doc-view")
@@ -34,16 +33,6 @@
 (declare-function nov-render-document "ext:nov")
 (declare-function org-attach-dir "org-attach")
 (declare-function org-attach-file-list "org-attach")
-(declare-function pdf-info-getannots "ext:pdf-info")
-(declare-function pdf-info-gettext "ext:pdf-info")
-(declare-function pdf-info-outline "ext:pdf-info")
-(declare-function pdf-info-pagelinks "ext:pdf-info")
-;; (declare-function pdf-util-tooltip-arrow "ext:pdf-util")
-(declare-function pdf-view-active-region "ext:pdf-view")
-(declare-function pdf-view-active-region-p "ext:pdf-view")
-(declare-function pdf-view-active-region-text "ext:pdf-view")
-(declare-function pdf-view-goto-page "ext:pdf-view")
-(declare-function pdf-view-mode "ext:pdf-view")
 
 ;; --------------------------------------------------------------------------------
 ;;; User variables


### PR DESCRIPTION
I'm trying to move all `pdf-tools`-specific functions out of `-core.el` and into `modules/-pdf.el`.  The first 3 commits are just renames so everything in the modules start with `org-noter-<module>--...`.   46e639afde004e709b656ed215a16172c9ebc686 moves the `-show-arrow` function, makes a hook and adds the moved function to the hook in the usual way.

In 7bd11455e482aeaef2b7a8faf5449ee182256b3a, I take the `(require 'pdf-tools)` out of `-core.el` and it breaks the packaged version of org-noter, but not my local copy.  Specifically, the arrow stops showing up and emacs claims it knows nothing about the pdf-tools function `pdf-view-current-overlay`.

In be255124f2b559744a7203a7c9348aa0a469e117, the explicit call outside of `condition-case` fixes the "bug," but that subverts the intent of the `condition-case` that was brought in at PR #13 to fix issue #9.

1aaea1297d34d7348e2be783b8d4e9ce86459d38 shows that the calls to `declare-function` have no effect on the behavior of the code.