### PR TITLE
Feature/save notes when quitting

### DIFF
--- a/README.org
+++ b/README.org
@@ -98,6 +98,9 @@
      the document to annotate.
 
 *** new (all formats)
+    - ~defcustom org-noter-save-notes-at-end-of-session~ :: Save notes buffer
+      when killing session.  Default value under discussion.
+
     - ~org-noter-start-from-dired~ (Suggested keybinding: ~M-s n~) :: Start
       sessions directly from ~dired~.  Opens all marked files or the file at
       point if none are marked.

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -38,7 +38,7 @@
 (defvar-local org-noter--nov-timer nil
   "Timer for synchronizing notes after scrolling.")
 
-(defun org-noter-nov--get-buffer-file-name (&optional mode)
+(defun org-noter-nov--get-buffer-file-name (&optional _mode)
   (bound-and-true-p nov-file-name))
 
 (add-to-list 'org-noter-get-buffer-file-name-hook #'org-noter-nov--get-buffer-file-name)
@@ -96,7 +96,7 @@
 
 (add-to-list 'org-noter--get-precise-info-hook #'org-noter-nov--get-precise-info)
 
-(defun org-noter-nov--goto-location (mode location &optional window)
+(defun org-noter-nov--goto-location (mode location &optional _window)
   (when (eq mode 'nov-mode)
     (setq nov-documents-index (org-noter--get-location-page location))
     (nov-render-document)

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -69,7 +69,7 @@
 
 (defun org-noter-nov--no-sessions-remove-advice ()
   "Remove nov-specific advice when all sessions are closed."
-  (advice-remove 'nov-render-document 'org-noter--nov-scroll-handler))
+  (advice-remove 'nov-render-document 'org-noter-nov--scroll-handler))
 
 (add-to-list 'org-noter--no-sessions-remove-advice-hooks #'org-noter-nov--no-sessions-remove-advice)
 

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -44,14 +44,13 @@
 (add-to-list 'org-noter-get-buffer-file-name-hook #'org-noter-nov--get-buffer-file-name)
 
 (defun org-noter-nov--approx-location-cons (mode &optional precise-info _force-new-ref)
-  (org-noter--with-valid-session
-   (when (eq mode 'nov-mode)
-     (cons nov-documents-index (if (or (numberp precise-info)
-                                       (and (consp precise-info)
-                                            (numberp (car precise-info))
-                                            (numberp (cdr precise-info))))
-                                   precise-info
-                                 (max 1 (/ (+ (window-start) (window-end nil t)) 2)))))))
+  (when (eq mode 'nov-mode)
+    (cons nov-documents-index (if (or (numberp precise-info)
+                                      (and (consp precise-info)
+                                           (numberp (car precise-info))
+                                           (numberp (cdr precise-info))))
+                                  precise-info
+                                (max 1 (/ (+ (window-start) (window-end nil t)) 2))))))
 
 (add-to-list 'org-noter--doc-approx-location-hook #'org-noter-nov--approx-location-cons)
 

--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -35,6 +35,8 @@
 
 (defvar nov-documents-index)
 (defvar nov-file-name)
+(defvar-local org-noter--nov-timer nil
+  "Timer for synchronizing notes after scrolling.")
 
 (defun org-noter-nov--get-buffer-file-name (&optional mode)
   (bound-and-true-p nov-file-name))
@@ -53,13 +55,24 @@
 
 (add-to-list 'org-noter--doc-approx-location-hook #'org-noter-nov--approx-location-cons)
 
+(defun org-noter-nov--scroll-handler (&rest _)
+  (when org-noter--nov-timer (cancel-timer org-noter--nov-timer))
+  (unless org-noter--inhibit-location-change-handler
+    (setq org-noter--nov-timer (run-with-timer 0.25 nil 'org-noter--doc-location-change-handler))))
+
 (defun org-noter-nov--setup-handler (mode)
   (when (eq mode 'nov-mode)
-    (advice-add 'nov-render-document :after 'org-noter--nov-scroll-handler)
-    (add-hook 'window-scroll-functions 'org-noter--nov-scroll-handler nil t)
+    (advice-add 'nov-render-document :after 'org-noter-nov--scroll-handler)
+    (add-hook 'window-scroll-functions 'org-noter-nov--scroll-handler nil t)
     t))
 
 (add-to-list 'org-noter-set-up-document-hook #'org-noter-nov--setup-handler)
+
+(defun org-noter-nov--no-sessions-remove-advice ()
+  "Remove nov-specific advice when all sessions are closed."
+  (advice-remove 'nov-render-document 'org-noter--nov-scroll-handler))
+
+(add-to-list 'org-noter--no-sessions-remove-advice-hooks #'org-noter-nov--no-sessions-remove-advice)
 
 (defun org-noter-nov--pretty-print-location (location)
   (org-noter--with-valid-session

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -95,6 +95,12 @@ MODE (unused) is required for this type of hook."
 
 (add-to-list 'org-noter-set-up-document-hook #'org-noter-pdf--doc-view-setup-handler)
 
+(defun org-noter-pdf--no-sessions-remove-advice ()
+  "Remove doc-view-specific advice when all sessions are closed."
+  (advice-remove 'doc-view-goto-page 'org-noter--location-change-advice))
+
+(add-to-list 'org-noter--no-sessions-remove-advice-hooks #'org-noter-pdf--no-sessions-remove-advice)
+
 (defun org-noter-pdf--pretty-print-location (location)
   "Formats LOCATION with full precision for property drawers."
   (org-noter--with-valid-session

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -119,6 +119,11 @@ start at the beginning of the document."
   :group 'org-noter
   :type 'boolean)
 
+(defcustom org-noter-save-notes-at-end-of-session nil
+  "Save the notes file when killing a session."
+  :group 'org-noter
+  :type 'boolean)
+
 (defcustom org-noter-prefer-root-as-file-level nil
   "Option to preferentially use the file-level property drawer.
 
@@ -1969,6 +1974,9 @@ want to kill."
             (delete-window window))))
 
       (with-current-buffer notes-buffer
+        (when org-noter-save-notes-at-end-of-session
+          (save-buffer)
+          (setq notes-modified (buffer-modified-p notes-buffer)))
         (remove-hook 'kill-buffer-hook 'org-noter--handle-kill-buffer t)
         (restore-buffer-modified-p nil))
       (when org-noter-use-indirect-buffer


### PR DESCRIPTION
Merge the nov-stuff before this one.  Only the last two commits 80ed3eb99ea52bc57805255322ef2da4eb6bea7a and ee27a360bcbb63fe5569f2c53a101a33d6f4a8d9 directly pertain to this feature.

For now, it's written so that the new `defcustom` is defaulted to `nil`, but I'm thinking it maybe better to default it to `t` because otherwise it won't be discovered by users.  I find it irritating to have to switch over to the notes buffer to save it before closing, and I'm much happier with the feature in my setup; however, we may come across some who are offended that the buffer is saved without their express intervention.