### PR TITLE
Add issue template and PR template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Something's not working.
+title: ""
+labels: ""
+assignees: ""
+---
+
+### Description
+
+#### Steps to Reproduce
+
+<!--
+Example:
+
+1. Load Emacs
+2. Open a pdf document
+3. Run M-x org-noter
+...
+-->
+
+#### Backtrace
+<!--
+   Will help us track and understand issues faster.
+   How to provide a backtrace:
+   1. M-x toggle-debug-on-error
+   2. Trigger error. The debugger buffer should pop up.
+   3. Copy the contents of the debugger buffer and paste here
+-->
+
+#### Expected Results
+
+<!-- Example: org-noter opens -->
+
+#### Actual Results
+
+<!-- Example: org-noter does not open -->
+
+### Environment
+
+<!-- Please M-x org-version and paste results here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+## Problem
+
+<!--
+
+Example:
+
+I'm looking to add a new feature to org-noter that makes the whole experience so much better.
+
+-->
+
+
+## Solution
+
+<!--
+
+Example:
+
+I added new feature called blah blah and it's great.
+
+-->
+
+
+## Checklist
+
+- [ ] I checked the code to make sure that it works on my machine.
+- [ ] I checked that the code works without my custom emacs config.
+- [ ] I added unit tests.
+
+## Steps to Test
+
+
+<!--
+
+Example:
+
+1. open a pdf and start org noter document
+2. execute org-noter-new-fancy-feature
+3. you should expect the new fancy features to do something
+
+-->
+
+
+## [Optional] Screenshots
+
+<!--
+
+Where reasonable include a screenshot to help us visualize what this does.
+
+-->


### PR DESCRIPTION
Hey @petermao, I'd like to add some structure to issues and PR templates. Github has this functionality via the PR templates. I borrowed org-roams for bug reports, you can test drive it here: https://github.com/org-roam/org-roam/issues/new/choose

For PRs, I kinda winged it. The goal is to have some structure around these things. 