### PR TITLE
Add test coverage to builds.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Run tests
         run: cask exec buttercup -L .
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2

--- a/Cask
+++ b/Cask
@@ -7,3 +7,4 @@
 (depends-on "with-simulated-input")
 
 (depends-on "log4e")
+(depends-on "undercover")

--- a/README.org
+++ b/README.org
@@ -1,7 +1,6 @@
 * Org-noter: an interleaving/note-taking package for documents
-  [[https://melpa.org/#/org-noter][file:https://melpa.org/packages/org-noter-badge.svg]]
-
-  [![Coverage Status](https://coveralls.io/repos/github/org-noter/org-noter/badge.svg?branch=master)](https://coveralls.io/github/org-noter/org-noter?branch=master)
+  [[https://melpa.org/#/org-noter][file:https://melpa.org/packages/org-noter-badge.svg]] 
+  [[https://coveralls.io/github/org-noter/org-noter?branch=master][file:https://coveralls.io/repos/github/org-noter/org-noter/badge.svg?branch=master]]
 
   ~Org-noter~, by [[https://github.com/weirdNox][Gonçalo Santos]], was inspired by the now-orphaned ~Interleave~
   package, by [[https://github.com/rudolfochrist][Sebastian Christ]].  In Sebastian's words (with minor edits):

--- a/README.org
+++ b/README.org
@@ -1,6 +1,8 @@
 * Org-noter: an interleaving/note-taking package for documents
   [[https://melpa.org/#/org-noter][file:https://melpa.org/packages/org-noter-badge.svg]]
 
+  [![Coverage Status](https://coveralls.io/repos/github/org-noter/org-noter/badge.svg?branch=master)](https://coveralls.io/github/org-noter/org-noter?branch=master)
+
   ~Org-noter~, by [[https://github.com/weirdNox][Gonçalo Santos]], was inspired by the now-orphaned ~Interleave~
   package, by [[https://github.com/rudolfochrist][Sebastian Christ]].  In Sebastian's words (with minor edits):
 

--- a/org-noter-test-utils.el
+++ b/org-noter-test-utils.el
@@ -1,5 +1,24 @@
-
 (require 'log4e)
+
+(message "Emacs version: %s" (version))
+
+;; we need to load undecover before all the other org-noter modules so that undercover can instrument code to generate test coverage.
+(when (require 'undercover nil t)
+  (setq undercover-force-coverage t)
+
+  (message "Enable test coverage.")
+  (undercover "*.el" "modules/*.el"
+              (:exclude "org-noter-test-utils.el")
+              (:report-format 'lcov)
+              (:send-report nil)))
+
+
+(add-to-list 'load-path "modules")
+(require 'org-noter)
+(require 'with-simulated-input)
+
+
+
 
 ;; org-noter-test logger = ont
 (log4e:deflogger "ont" "ont %t [%l] %m" "%H:%M:%S")

--- a/org-noter-test-utils.el
+++ b/org-noter-test-utils.el
@@ -1,7 +1,3 @@
-(require 'log4e)
-
-(message "Emacs version: %s" (version))
-
 ;; we need to load undecover before all the other org-noter modules so that undercover can instrument code to generate test coverage.
 (when (require 'undercover nil t)
   (setq undercover-force-coverage t)
@@ -13,9 +9,14 @@
               (:send-report nil)))
 
 
+(require 'log4e)
 (add-to-list 'load-path "modules")
 (require 'org-noter)
 (require 'with-simulated-input)
+
+
+(message "Emacs version: %s" (version))
+
 
 
 

--- a/tests/org-noter-core-tests.el
+++ b/tests/org-noter-core-tests.el
@@ -1,5 +1,4 @@
 (add-to-list 'load-path "modules")
-(require 'org-noter)
 (require 'with-simulated-input)
 (require 'org-noter-test-utils)
 

--- a/tests/org-noter-extra-tests.el
+++ b/tests/org-noter-extra-tests.el
@@ -1,9 +1,5 @@
 
 (add-to-list 'load-path "modules")
-(require 'org-noter-pdf)
-(require 'with-simulated-input)
-(require 'org-noter-test-utils)
-
 
 (describe "org-noter very custom behavior"
           (before-each

--- a/tests/org-noter-pdf-tests.el
+++ b/tests/org-noter-pdf-tests.el
@@ -1,5 +1,4 @@
 (add-to-list 'load-path "modules")
-(require 'org-noter-pdf)
 (require 'org-noter-test-utils)
 
 


### PR DESCRIPTION
## Problem

Improve code quality by including a code coverage badge.

## Solution

Use undercover to generate code coverage and then coveralls.io to visualize this.

## Checklist

This is strictly an on-commit github workflow and doesn't affect org-noter  itself.

## Steps to Test

See the github workflow succeed.

## [Optional] Screenshots

If you go to https://github.com/org-noter/org-noter/tree/feature/add-test-coverage you should see the badge. It's showing coverage for `master` branch and it won't show up until we merge this to master.

<img width="506" alt="image" src="https://github.com/org-noter/org-noter/assets/707020/b6ffac1e-e02f-4769-86b3-df5f465cc12c">


