### PR TITLE
Linting during building/CI?

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+((emacs-lisp-mode . ((fill-column . 120)
+                     (indent-tabs-mode . nil)
+                     (elisp-lint-ignored-validators . ("byte-compile"))
+                     (elisp-lint-indent-specs . ((describe . 1)
+                                                 (it . 1))))))

--- a/Cask
+++ b/Cask
@@ -6,4 +6,8 @@
 
 (depends-on "with-simulated-input")
 
+(depends-on "flycheck")
+
+(depends-on "elisp-lint")
+
 (depends-on "log4e")

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ compile: cask
 .PHONY: test
 test: compile
 	cask exec buttercup -L .
+
+
+lint: cask
+	cask emacs -Q --batch -l elisp-lint.el -f elisp-lint-files-batch *.el

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -4,7 +4,7 @@
 
 ;; Author: Gonçalo Santos (aka. weirdNox@GitHub)
 
-;; Package-Requires: ((emacs "27.2") (org "9.0"))
+;; Package-Requires: ((emacs "27.2") (org "9.4"))
 
 ;; This file is not part of GNU Emacs.
 

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -4,6 +4,8 @@
 
 ;; Author: Gonçalo Santos (aka. weirdNox@GitHub)
 
+;; Package-Requires: ((emacs "27.2") (org "9.0"))
+
 ;; This file is not part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-noter.el
+++ b/org-noter.el
@@ -8,7 +8,7 @@
 ;;             Dmitry M <dmitrym@gmail.com>
 ;; Homepage: https://github.com/org-noter/org-noter
 ;; Keywords: lisp pdf interleave annotate external sync notes documents org-mode
-;; Package-Requires: ((emacs "27.2") (org "9.0"))
+;; Package-Requires: ((emacs "27.2") (org "9.4"))
 ;; Version: 1.5.0
 
 ;; This file is not part of GNU Emacs.

--- a/org-noter.el
+++ b/org-noter.el
@@ -8,7 +8,7 @@
 ;;             Dmitry M <dmitrym@gmail.com>
 ;; Homepage: https://github.com/org-noter/org-noter
 ;; Keywords: lisp pdf interleave annotate external sync notes documents org-mode
-;; Package-Requires: ((emacs "24.4") (cl-lib "0.6") (org "9.0"))
+;; Package-Requires: ((emacs "27.2") (org "9.0"))
 ;; Version: 1.5.0
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
@petermao in https://github.com/org-noter/org-noter/pull/32  you mentioned a linter, I realized that I haven't run one in a while. 

You can run this from command line:

1. `cask` to update dependencies
2. `make lint`

Unfortunately there are a million warnings..

Some make a lot of sense though:

```
org-noter-core.el:0:0 (checkdoc) You should have a section marked ";;; Commentary:"
```

```
org-noter-core.el:1089:0 (package-lint-error) "org-noter--doc-file-property" doesn't start with package's prefix "org-noter-core".
```

```
org-noter.el:11:64 (package-lint-warning) An explicit dependency on cl-lib <= 1.0 is not needed on Emacs >= 24.3.
```

Don't know how to separate the existing linter errors from the new linter errors we're creating :)