### PR TITLE
override annoying pdf-view-mode and doc-view-mode keybindings

### DIFF
--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -503,14 +503,14 @@ current heading inherit the COLUMN_EDGES property."
 (define-key org-noter-doc-mode-map (kbd "C-c C-c")
   (lambda ()
     (interactive)
-    (other-window 1)
+    (select-window (org-noter--get-notes-window))
     (org-ctrl-c-ctrl-c)))
 
 (defun org-noter-pdf--execute-CxCc-in-notes ()
   "Execute C-c C-x prefixed command in notes buffer."
   (interactive)
   (let ((this-CxCc-cmd (vector (read-event))))
-    (other-window 1)
+    (select-window (org-noter--get-notes-window))
     (execute-kbd-macro
      (vconcat (kbd "C-c C-x") this-CxCc-cmd))))
 (define-key org-noter-doc-mode-map (kbd "C-c C-x") 'org-noter-pdf--execute-CxCc-in-notes)

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -501,19 +501,20 @@ current heading inherit the COLUMN_EDGES property."
 
 ;;; override some deleterious keybindings in pdf-view-mode.
 (define-key org-noter-doc-mode-map (kbd "C-c C-c")
-  (lambda ()
+  (defun org-noter-pdf--execute-CcCc-in-notes ()
+    "Override C-c C-c in pdf document buffer."
     (interactive)
     (select-window (org-noter--get-notes-window))
     (org-ctrl-c-ctrl-c)))
 
-(defun org-noter-pdf--execute-CxCc-in-notes ()
-  "Execute C-c C-x prefixed command in notes buffer."
-  (interactive)
-  (let ((this-CxCc-cmd (vector (read-event))))
-    (select-window (org-noter--get-notes-window))
-    (execute-kbd-macro
-     (vconcat (kbd "C-c C-x") this-CxCc-cmd))))
-(define-key org-noter-doc-mode-map (kbd "C-c C-x") 'org-noter-pdf--execute-CxCc-in-notes)
+(define-key org-noter-doc-mode-map (kbd "C-c C-x")
+  (defun org-noter-pdf--execute-CcCx-in-notes ()
+    "Override C-c C-x <event> in pdf document buffer."
+    (interactive)
+    (let ((this-CxCc-cmd (vector (read-event))))
+      (select-window (org-noter--get-notes-window))
+      (execute-kbd-macro
+       (vconcat (kbd "C-c C-x") this-CxCc-cmd)))))
 
 (provide 'org-noter-pdf)
 ;;; org-noter-pdf.el ends here

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -499,5 +499,20 @@ current heading inherit the COLUMN_EDGES property."
     (select-window (org-noter--get-notes-window))
     (org-entry-put nil "COLUMN_EDGES" (format "%s" (princ edge-list)))))
 
+;;; override some deleterious keybindings in pdf-view-mode.
+(define-key org-noter-doc-mode-map (kbd "C-c C-c")
+  (lambda ()
+    (interactive)
+    (other-window 1)
+    (org-ctrl-c-ctrl-c)))
+
+(define-prefix-command 'org-noter-pdf-view-prefix)
+(define-key org-noter-doc-mode-map (kbd "C-c C-x") 'org-noter-pdf-view-prefix)
+(define-key org-noter-pdf-view-prefix (kbd "C-v")
+  (lambda ()
+    (interactive)
+    (other-window 1)
+    (org-toggle-inline-images)))
+
 (provide 'org-noter-pdf)
 ;;; org-noter-pdf.el ends here

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -506,13 +506,14 @@ current heading inherit the COLUMN_EDGES property."
     (other-window 1)
     (org-ctrl-c-ctrl-c)))
 
-(define-prefix-command 'org-noter-pdf-view-prefix)
-(define-key org-noter-doc-mode-map (kbd "C-c C-x") 'org-noter-pdf-view-prefix)
-(define-key org-noter-pdf-view-prefix (kbd "C-v")
-  (lambda ()
-    (interactive)
+(defun org-noter-pdf--execute-CxCc-in-notes ()
+  "Execute C-c C-x prefixed command in notes buffer."
+  (interactive)
+  (let ((this-CxCc-cmd (vector (read-event))))
     (other-window 1)
-    (org-toggle-inline-images)))
+    (execute-kbd-macro
+     (vconcat (kbd "C-c C-x") this-CxCc-cmd))))
+(define-key org-noter-doc-mode-map (kbd "C-c C-x") 'org-noter-pdf--execute-CxCc-in-notes)
 
 (provide 'org-noter-pdf)
 ;;; org-noter-pdf.el ends here

--- a/tests/org-noter-pdf-tests.el
+++ b/tests/org-noter-pdf-tests.el
@@ -40,10 +40,30 @@
                                       (expect (string-match "\\:HIGHLIGHT\\:" (buffer-string))  :not :to-be nil)
                                       (expect (string-match (format "%s" expected-highlight-info) (buffer-string))  :not :to-be nil)
                                       )
-
-                                   ))
-
+                                   )
+                                  )
                               )
+                    )
 
+          (describe "pdf keybinding overrides"
+                    (it "C-c C-c called from a PDF document executes in the notes buffer"
+                        ;; open `org-noter' session with PDF and notes
+
+                        ;; execute `C-c C-c' from document buffer
+
+                        ;; check that current window is notes-window, check that
+                        ;; last command was `org-ctrl-c-ctrl-c'
+                        )
+
+                    (it "C-c C-x <event> called from a PDF document executes in the notes buffer"
+                        ;; open `org-noter' session with PDF and notes
+
+                        ;; execute `C-c C-x <event>' from document buffer, where
+                        ;; <event> \in {C-b, C-v, maybe a few others}
+
+                        ;; check that current window is notes-window, check that
+                        ;; last command corresponds to the keybinding of C-c C-x
+                        ;; <event>.
+                        )
                     )
           )


### PR DESCRIPTION
First attempt to deal with Issue #41.

Thus far, this takes keybindings that would not normally be used in pdf-view-mode buffer when running org-noter and runs those keybindings in the notes buffer as if focus was there all along.

`C-c C-c` is used by org-babel to run code.  If user has focus on the document, then it would normally run `doc-view-toggle-display`, which takes the doc buffer out of org-noter-doc-mode.

`C-c C-x C-v` is used by org-babel to toggle inline images.  If user has focus on the document, then `C-c C-x` would normally run `image-toggle-hex-display`, which takes the doc buffer out of org-noter-doc-mode.

## Problem

I use two keybindings above frequently when running org-babel and generating figures while using `org-noter`, but often enough, I accidentally hit them with focus on the wrong window, which screws up my `org-noter` session.


## Solution

In the pdf module, I have rebound those keys in `org-noter-doc-mode-map` so that `(select-window (org-noter--get-notes-window))` is run first, followed by the `org-mode` command of the keybinding.


## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [x] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

1. open a pdf and start org noter document
2. issue one of the keybindings from the document buffer
3. should see same behavior in notes buffer as when that keybinding is issued from the notes buffer.

## Known issues (thus far)

1. ~~Assumes use of `pdftools` and not `doc-view` for pdfs.~~ Works in `doc-view`, too.
2. ~~Assumes that the notes buffer is *not* in a separate frame.~~

## It would be nice if...

- [X] ...this ~~could be~~ is generalized so that any `C-c C-x` prefixed keybinding issued from the document buffer would switch over to the notes buffer and run the corresponding `org-mode` command.
