### PR TITLE
nonbug-bugfix: insertion of new headline title

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -266,7 +266,7 @@ DOCUMENT-FILE-NAME is the document filename."
               (setq notes-files-annotating notes-files)
             (with-current-buffer (find-file-noselect (car notes-files))
               (goto-char (point-max))
-              (insert (if (save-excursion (beginning-of-line) (looking-at "[[:space:]]*$")) "" "\n")
+              (insert (if (save-excursion (backward-char) (looking-at-p "\n")) "" "\n")
                       "* " document-base)
               (org-entry-put nil org-noter-property-doc-file
                              (file-relative-name document-used-path


### PR DESCRIPTION
In the original code, if there is whitespace on the last line of the file, then the headline *should* insert after the whitespace, but it doesn't!  I don't understand the magic that makes this happen.

In this bugfix, we look for `\n` as the last character of the file and add `\n` before "* <title>" if the last character is anything else.  This requires no magic to work.

## Problem

Surprisingly, there is no problem


## Solution

The new code should be more future-proof than the existing code


## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [ ] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

1. Have a Notes.org file with other noter annotations of other documents
2. Add whitespace to the last line of the file with no newline at the end
3. Open a pdf and start org noter so the heading goes into the aforementioned Notes.org file
4. Observe whether the new heading starts on the last line after the whitespace (it does not) or if it starts on a new line starting with `* ` (it does).
