### PR TITLE
add optional decoration to headline title

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -334,7 +334,23 @@ If it exists, it will be listed as a candidate that `org-noter'
 will have the user select to use as the note file of the
 document."
   :group 'org-noter
-  :type 'hook)
+  :type 'hook
+  :version "28.2")
+
+(defcustom org-noter-headline-title-decoration ""
+  "Decoration (emphasis) for the headline title string.
+
+If you use the Org STARTUP option 'entitiespretty', filenames
+with underscores will end up looking ugly.  This string is
+prepended and appended to the document title in the top-level
+headline, making it look nicer.
+
+Reasonable choices are: /, *, =, ~, _
+
+With '/', 'The_Title' would become '/The_Title/'."
+  :group 'org-noter
+  :type 'string
+  :version "28.2")
 
 (defface org-noter-no-notes-exist-face
   '((t

--- a/org-noter.el
+++ b/org-noter.el
@@ -267,7 +267,10 @@ DOCUMENT-FILE-NAME is the document filename."
             (with-current-buffer (find-file-noselect (car notes-files))
               (goto-char (point-max))
               (insert (if (save-excursion (beginning-of-line) (looking-at "[[:space:]]*$")) "" "\n")
-                      "* " document-base)
+                      "* "
+                      org-noter-headline-title-decoration
+                      document-base
+                      org-noter-headline-title-decoration)
               (org-entry-put nil org-noter-property-doc-file
                              (file-relative-name document-used-path
                                                  (file-name-directory (car notes-files)))))


### PR DESCRIPTION
With `entitiespretty`, underscores in titles look terrible, but org's emphasis decorations make them readable again with minimal disturbance.

## Problem

Purely cosmetic issue when using `entitespretty` with underscores in the filenames.


## Solution

New custom variable `org-noter-headline-title-decoration`, default `""`.   Customize to `/` (italics),  `_` (underline), or any other Org emphasis marker (`=`, `~`, `+`).


## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [x] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

1. open a pdf and start org noter document
2. customize `org-noter-headline-title-decoration`
3. new headline (document) titles are prepended and appended with the decoration, hiding the formatting from `entitespretty`

