### PR TITLE
README.org: add installation instructions with Emacs 29.1

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,8 +50,7 @@
 (use-package org-noter
   :load-path "<path-to-org-noter>"
   :ensure t
-  :demand t
-  )
+  :demand t)
 #+end_src
 
 *** straight.el

--- a/README.org
+++ b/README.org
@@ -44,6 +44,16 @@
         (require 'org-noter)
       #+end_src
 
+*** vanilla Emacs after version 29.1, which includes use-package
+
+#+begin_src elisp
+(use-package org-noter
+  :load-path "<path-to-org-noter>"
+  :ensure t
+  :demand t
+  )
+#+end_src
+
 *** straight.el
     In plain ~straight.el~ syntax
     #+begin_src elisp


### PR DESCRIPTION
Emacs 29.1 ships use-package. Give example of using it.

## Problem

Emacs 29.1 ships `use-package` by default. Offer an example how to use it with `org-noter`. 

## Solution

I added and example to `README.org`.

## Checklist

- [x] I checked the code to make sure that it works on my machine.
- [x] I checked that the code works without my custom emacs config.
- [ ] I added unit tests. (No unit tests, because this code is user-facing.)

## Steps to Test

Add 
```
(use-package org-noter
  :load-path "<path-to-org-noter>"
  :ensure t
  :demand t
  )
```
 to your `~/.emacs.d/init.el`

