### PR TITLE
Remove trailing "/" when expand load-path

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -47,7 +47,7 @@
 (declare-function org-entry-put "org")
 (declare-function org-with-wide-buffer "org-macs")
 
-(add-to-list 'load-path (concat (file-name-directory load-file-name) "modules/"))
+(add-to-list 'load-path (concat (file-name-directory load-file-name) "modules"))
 (when (or (memq 'doc-view-mode org-noter-supported-modes)
           (memq 'pdf-view-mode org-noter-supported-modes))
   (require 'org-noter-pdf))


### PR DESCRIPTION
Some distributions, such as Nixpkgs, use
`normal-top-level-add-subdirs-to-load-path' to recursively add sub dirs of load-path entries to load-path.

org-note also does this when it is loaded using `add-to-list'. Ideally, this should be a no-op since `add-to-list' does deduplication.  However, the entry org-noter adds has a trailing "/", which is not the case for other entries of `load-path'[1].  As a result, the deduplication fails.

[1]: See the source code of `normal-top-level-add-to-load-path'.

## Problem

Duplicate entry in load-path: /prefix/share/emacs/site-lisp/elpa/org-noter-20230728.2037/modules/


## Solution

Remove the trailing "/" when adding that path to load-path.


## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [X] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.


