### PR TITLE
in `--doc-file-property`, ensure buffer is org-mode or pass

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -1125,10 +1125,11 @@ FORCE-NEW-REF is not used by PDF, NOV, or DJVU format files."
   (org-noter--with-valid-session (org-noter--doc-location-change-handler)))
 
 (defsubst org-noter--doc-file-property (headline)
-  (let ((doc-prop (or (org-element-property (intern (concat ":" org-noter-property-doc-file)) headline)
-                      (org-entry-get nil org-noter-property-doc-file t))))
-    (or (run-hook-with-args-until-success 'org-noter-parse-document-property-hook doc-prop)
-        doc-prop)))
+  (when (derived-mode-p 'org-mode)
+    (let ((doc-prop (or (org-element-property (intern (concat ":" org-noter-property-doc-file)) headline)
+                        (org-entry-get nil org-noter-property-doc-file t))))
+      (or (run-hook-with-args-until-success 'org-noter-parse-document-property-hook doc-prop)
+          doc-prop))))
 
 (defun org-noter--check-location-property (arg)
   (let ((property (if (stringp arg) arg


### PR DESCRIPTION
## Problem

See Issue #61.


## Solution

The offending command is `org-noter--doc-file-property` which should only run if the `current-buffer` is and Org-mode-derived buffer.  The change skips the body of the code unless the buffer is and Org buffer.

## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [X] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

Check against Org 9.6.8 and Org 9.7pre (any commit after f1359546a)

Using `speed-test` and Org 9.6.8, I clocked Moby Dick at 15.07 and 13.29 s, which is significantly faster than using the commit before this one.