### PR TITLE
Fixes #68

### DIFF
--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -415,7 +415,7 @@ Each column is specified by its right edge as a fractional
 horizontal position.  Output is nil for standard notes and (page
 v') for precise notes."
   (if-let* ((_ (and (consp location) (consp (cdr location))))
-            (column-edges-string (org-entry-get nil "COLUMN_EDGES" t))
+            (column-edges-string (when (derived-mode-p 'org-mode) (org-entry-get nil "COLUMN_EDGES" t)))
             (right-edge-list (car (read-from-string column-edges-string)))
             ;;(ncol (length left-edge-list))
             (page (car location))


### PR DESCRIPTION
org-entry-get now throws an error if not in org-mode. Fixes pdf-view scrolling problems due to error in `pdf-view-after-change-page-hook`. See #68  for details. Inspired by #63.

Please make sure this is the correct solution / implement a different one before merging! It seems to work at a glance but I do not understand exactly how this function is used I just tried to fix the problem so I can continue working :).

## Checklist

- [x] I checked the code to make sure that it works on my machine.
- [x] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.
