### PR TITLE
Add focus behavior setting

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -356,6 +356,13 @@ With '/', 'The_Title' would become '/The_Title/'."
   :type 'string
   :version "28.2")
 
+(defcustom org-noter-focus-doc-after-note-navigation t
+  "Focus behavior.
+When non-nil, automatically focus the PDF window after moving
+between notes. When nil, leave focus in current window."
+  :group 'org-noter
+  :type 'boolean)
+
 (defface org-noter-no-notes-exist-face
   '((t
      :foreground "chocolate"
@@ -2500,7 +2507,8 @@ As such, it will only work when the notes window exists."
            (org-noter--doc-goto-location (org-noter--parse-location-property previous))
            (org-noter--focus-notes-region (org-noter--make-view-info-for-single-note session previous)))
        (user-error "There is no previous note"))))
-  (select-window (org-noter--get-doc-window)))
+  (when org-noter-focus-doc-after-note-navigation
+    (select-window (org-noter--get-doc-window))))
 
 (defun org-noter-sync-current-note ()
   "Go the location of the selected note, in relation to where the point is.
@@ -2515,9 +2523,10 @@ As such, it will only work when the notes window exists."
              (org-noter--doc-goto-location location)
            (user-error "No note selected")))
      (user-error "You are inside a different document")))
-  (let ((window (org-noter--get-doc-window)))
-    (select-frame-set-input-focus (window-frame window))
-    (select-window window)))
+  (when org-noter-focus-doc-after-note-navigation
+    (let ((window (org-noter--get-doc-window)))
+      (select-frame-set-input-focus (window-frame window))
+      (select-window window))))
 
 (defun org-noter-sync-next-note ()
   "Go to the location of the next note, in relation to where the point is.
@@ -2539,7 +2548,8 @@ As such, it will only work when the notes window exists."
            (org-noter--doc-goto-location (org-noter--parse-location-property next))
            (org-noter--focus-notes-region (org-noter--make-view-info-for-single-note session next)))
        (user-error "There is no next note"))))
-  (select-window (org-noter--get-doc-window)))
+  (when org-noter-focus-doc-after-note-navigation
+    (select-window (org-noter--get-doc-window))))
 
 (defun org-noter-enable-update-renames ()
   "Enable `dired-rename-file' advice for moving docs and notes.


### PR DESCRIPTION
## Problem

https://github.com/org-noter/org-noter/issues/69

## Solution

I added a new configuration option called `org-noter-focus-doc-after-note-navigation`.

## Checklist

- [x] I checked the code to make sure that it works on my machine.
- [x] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

1. Configure `org-noter-focus-doc-after-note-navigation` to be `nil` (its default value is `t`).
2. Open a pdf and start org noter document.
3. Navigate between notes using `org-noter-sync-next-note`, `org-noter-sync-prev-note`, or `org-noter-sync-current-note`.
4. Your notes window will stay focused, instead of focus being moved to the document window.

## Questions

* Should I add unit tests (could probably use some help with that)?
* Should I add documentation? In that case where?