### PR TITLE
Option to never create a frame for new session

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -144,11 +144,13 @@ notes that are not annotating the current page."
 
 (defcustom org-noter-always-create-frame t
   "Create a new frame for each document session.
-When non-nil, org-noter will always create a new frame for the
+When 't' (default), org-noter will always create a new frame for the
 session.  When nil, it will use the selected frame if it does not
-belong to any other session."
+belong to any other session. When set to -1, a new frame will never
+be created."
   :group 'org-noter
   :type 'boolean)
+
 
 (defcustom org-noter-disable-narrowing nil
   "Disable narrowing in notes/org buffer."
@@ -691,11 +693,12 @@ Otherwise return the maximum value for point."
            :id (org-noter--get-new-id)
            :display-name display-name
            :frame
-           (if (or org-noter-always-create-frame
+           (if (and (not (eq org-noter-always-create-frame -1))
+                (or org-noter-always-create-frame
                    (catch 'has-session
                      (dolist (test-session org-noter--sessions)
                        (when (eq (org-noter--session-frame test-session) (selected-frame))
-                         (throw 'has-session t)))))
+                         (throw 'has-session t))))))
                (make-frame `((name . ,frame-name) (fullscreen . maximized)))
              (set-frame-parameter nil 'name frame-name)
              (selected-frame))


### PR DESCRIPTION
This PR makes it possible to tell org-noter to never open a seperate frame for a new session, even when there is already a session in the current frame.

## Problem

Many users use some kind of 'Workspaces' feature, such as [`persp-mode.el`](https://github.com/Bad-ptr/persp-mode.el). For example, Doom Emacs uses `persp-mode.el` by default. Such users might prefer to open another org-noter session in a new workspace, rather than in a new frame. This is not currently possible - even when `org-noter-always-create-frame` is set to `nil`, org-noter will still open a new frame if there is a session running in the current frame.

## Solution

If `org-noter-always-create-frame` is set to `-1`, org-noter will never create a new frame. Users can manually switch to a new workspace and start a new session there. In this way multiple sessions can run in the same frame.

## Checklist

- [x] I checked the code to make sure that it works on my machine.
- [ ] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

1. Evaluate `(setq org-noter-always-create-frame -1)`
2. Open any existing Org notes file
3. Run `M-x org-noter`
4. Open another existing Org notes file
5. Run `M-x org-noter`

A new frame should not be created.