### PR TITLE
Remove edebug defs.

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -765,7 +765,6 @@ Otherwise return the maximum value for point."
       nil)))
 
 (defmacro org-noter--with-valid-session (&rest body)
-  (declare (debug (body)))
   `(let ((session org-noter--session))
      (when (org-noter--valid-session session)
        (progn ,@body))))
@@ -1059,7 +1058,6 @@ Used by interactive note-window location functions."
           (set-window-dedicated-p doc-window t))))))
 
 (defmacro org-noter--with-selected-notes-window (error-str &rest body)
-  (declare (debug ([&optional stringp] body)))
   (let ((with-error (stringp error-str)))
     `(org-noter--with-valid-session
       (let ((notes-window (org-noter--get-notes-window)))


### PR DESCRIPTION
## Problem

The code coverage tool that we're using, undercover, did not work correctly to report code coverag. This is problem #34.

## Solution

I originally though that edebug needed hints to be included for the macros we use. It turns out that there are hints, and they are incorrect. Removing the hints makes code coverage work better.

## Checklist

- [x] I checked the code to make sure that it works on my machine.
- [x] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

See the "Checks" on this PR. Code coverage went from ~4% to 28% because edebug can now correctly analyze the code.
