### PR TITLE
Fix compile warnings

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -1878,7 +1878,7 @@ will continue to sync the document references."
               (setq this-org-file-uses-noter t)
               ;; sync the document path to the new notes file
               (org-set-property org-noter-property-doc-file new-doc-file-rel-path)
-              (next-line)
+              (forward-line)
               ;; add problematic paths to the list
               (when (string-prefix-p "../" new-doc-file-rel-path)
                 (push new-doc-file-rel-path problem-path-list)))))

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -344,14 +344,14 @@ document."
 (defcustom org-noter-headline-title-decoration ""
   "Decoration (emphasis) for the headline title string.
 
-If you use the Org STARTUP option 'entitiespretty', filenames
+If you use the Org STARTUP option \"entitiespretty\", filenames
 with underscores will end up looking ugly.  This string is
 prepended and appended to the document title in the top-level
 headline, making it look nicer.
 
 Reasonable choices are: /, *, =, ~, _
 
-With '/', 'The_Title' would become '/The_Title/'."
+With \"/\", \"The_Title\" would become \"/The_Title/\"."
   :group 'org-noter
   :type 'string
   :version "28.2")

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -62,7 +62,9 @@
 
 (defvar org-noter--doc-extensions nil
   "List of extensions handled by org-noter when documents are moved.
-Used by `org-noter--update-doc-rename-in-notes'.  This variable gets filled in by supported modes, so it is not a `defcustom' variable.")
+Used by `org-noter--update-doc-rename-in-notes'.  This variable
+gets filled in by supported modes, so it is not a `defcustom'
+variable.")
 
 (defcustom org-noter-property-doc-file "NOTER_DOCUMENT"
   "Name of the property that specifies the document."


### PR DESCRIPTION
## Problem

resolve a few compile warnings
* long docstring
* use `forward-line` instead of `next-line`
* \-escape "unescaped single quotes" in docstring


## Solution

Fixed those things.  Only code change is in `org-noter--update-notes-rename-in-notes`, which is activated via `org-noter-enable-sync-renames`.


## Checklist

- [ X ] I checked the code to make sure that it works on my machine.
- [ ] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

1. start org-noter
2. M-x org-noter-enable-sync-renames
3. move a notes file and verify that the paths to linked documents update.

