### PR TITLE
Fix buttercup

### DIFF
--- a/org-noter-test-utils.el
+++ b/org-noter-test-utils.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;; we need to load undecover before all the other org-noter modules so that undercover can instrument code to generate test coverage.
 (when (require 'undercover nil t)
   (setq undercover-force-coverage t)
@@ -26,7 +27,7 @@
 (ont--log-enable-logging)
 (ont--log-enable-debugging)
 (ont--log-enable-messaging)
-(ont--log-set-level 'info)
+(ont--log-set-level 'debug)
 (ont--log-debug "ont")
 
 
@@ -88,7 +89,9 @@
     (find-file tempfile)
     (org-mode)
     (ont--log-debug "Starting the test..")
+    (ont--log-debug "Buffer contents below:")
     (ont--log-debug "%s" (buffer-string))
+    (ont--log-debug "Invoking lambda")
     (funcall lambda)
     (ont--log-debug "About to kill buffer..")
     (kill-current-buffer)

--- a/org-noter-test-utils.el
+++ b/org-noter-test-utils.el
@@ -27,7 +27,7 @@
 (ont--log-enable-logging)
 (ont--log-enable-debugging)
 (ont--log-enable-messaging)
-(ont--log-set-level 'debug)
+(ont--log-set-level 'info)
 (ont--log-debug "ont")
 
 

--- a/tests/org-noter-core-tests.el
+++ b/tests/org-noter-core-tests.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 (add-to-list 'load-path "modules")
 (require 'with-simulated-input)
 (require 'org-noter-test-utils)

--- a/tests/org-noter-core-tests.el
+++ b/tests/org-noter-core-tests.el
@@ -16,14 +16,14 @@
                     (it "can parse a note file ast that is not empty"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda () (let ((mock-ast (org-noter--parse-root)))
+                         (lambda () (let ((mock-ast (org-noter--parse-root)))
                                            (expect mock-ast :not :to-be nil)))))
 
                     ;; basic note should insert a default heading
                     (it "can take a basic note"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (let ((org-noter-insert-note-no-questions t))
                               (org-noter-insert-note nil "NEW NOTE"))
@@ -34,7 +34,7 @@
                     (it "can take a precise note"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (with-simulated-input "precise SPC note RET"
                                                   (org-noter-insert-precise-note))
@@ -44,7 +44,7 @@
                     (it "precise note has precise data"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (with-simulated-input "precise SPC note RET"
                                                   (org-noter-insert-precise-note))
@@ -57,7 +57,7 @@
                     (it "precise note calls the highlight hook"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (with-simulated-input "precise SPC note RET"
                                                   (org-noter-insert-precise-note))
@@ -67,7 +67,7 @@
                     (it "precise note DOES NOT call the highlight hook when the note is aborted"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             ;; this is how you trap a C-g
                             (condition-case nil
@@ -84,7 +84,7 @@
                     (it "narrowed buffer is named correctly"
                         (with-mock-contents
                          mock-contents-simple-notes-file-with-a-single-note
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (let* ((session org-noter--session))
                               (expect (buffer-name (org-noter--session-notes-buffer session)) :to-equal "Notes of solove-nothing-to-hide")
@@ -94,7 +94,7 @@
                     (it "session properties are set correctly"
                         (with-mock-contents
                          mock-contents-simple-notes-file-with-a-single-note
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (let* ((session org-noter--session))
                               (expect (org-noter--session-property-text session) :to-equal "pubs/solove-nothing-to-hide.pdf")
@@ -114,7 +114,7 @@
                     (it "can get view info"
                         (with-mock-contents
                          mock-contents-simple-notes-file-with-a-single-note
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (let* ((view-info (org-noter--get-view-info (org-noter--get-current-view))))
                               (expect 'org-noter-core-test-get-current-view :to-have-been-called)
@@ -175,7 +175,7 @@
                               (it "can take a precise note without a highlight appearing"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (org-noter-core-test-create-session)
                                       (with-simulated-input "precise SPC note RET"
                                                             (org-noter-insert-precise-note))
@@ -192,7 +192,7 @@
                               (it "can take a precise note WITH a highlight appearing"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (org-noter-core-test-create-session)
                                       (with-simulated-input "precise SPC note RET"
                                                             (org-noter-insert-precise-note))
@@ -207,7 +207,7 @@
                     (it "can start org-noter with `org-noter` call"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             ;; move to the heading where we're going to invoke org-noter
                             (search-forward "nothing-to-hide")
                             (org-noter))))

--- a/tests/org-noter-extra-tests.el
+++ b/tests/org-noter-extra-tests.el
@@ -1,4 +1,4 @@
-
+;;; -*- lexical-binding: t; -*-
 (add-to-list 'load-path "modules")
 
 (describe "org-noter very custom behavior"
@@ -29,7 +29,7 @@
                     (it "should insert the highlighted text as an org-mode QUOTE when advice is enabled."
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             ;; we're not specifying the note title
                             (with-simulated-input "RET"
@@ -45,7 +45,7 @@
                     (it "should revert back to standard title"
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (org-noter-core-test-create-session)
                             (with-simulated-input "RET"
                                                   (org-noter-insert-precise-note))

--- a/tests/org-noter-location-tests.el
+++ b/tests/org-noter-location-tests.el
@@ -1,3 +1,5 @@
+;;; -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path "modules")
 (require 'org-noter-test-utils)
 
@@ -41,7 +43,7 @@ Test
                               (it "can parse a page location"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file-with-locations
-                                   '(lambda ()
+                                   (lambda ()
                                       (org-noter-core-test-create-session)
                                       (search-forward "Heading2")
                                       (expect (org-noter--get-containing-heading) :not :to-be nil)

--- a/tests/org-noter-org-roam-tests.el
+++ b/tests/org-noter-org-roam-tests.el
@@ -24,23 +24,16 @@
                                       ;; ADOCUMENT should come after solove-nothing-to-hide
                                       (expect (string-match "solove-nothing-to-hide" (buffer-string)) :to-be-less-than
                                               (string-match "ADOCUMENT" (buffer-string)))
-                                      (message (buffer-string)))))
+                                      )))
 
                               (it "can find an existing heading without creating a new one"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
                                    (lambda ()
                                       (let* ((found-heading-pos (org-noter--find-create-top-level-heading-for-doc "/tmp/test.pdf" "solove-nothing-to-hide")))
-                                      (message "\n00 ----")
                                       (goto-char found-heading-pos)
                                       (insert "!!")
-                                      (message (buffer-string))
-                                      (message "\n00 ----")
-
-                                      (expect found-heading-pos :to-be 141)
-                                      (message "----")
-                                      (message (buffer-string))
-                                      (message "---- %s" (length (buffer-string)))))))
+                                      (expect found-heading-pos :to-be 141)))))
 
 
                               (it "can create a new heading"
@@ -50,12 +43,7 @@
                                       (expect
                                        ;; org-noter-test-file is defined in test-utils.
                                        (org-noter--find-create-top-level-heading-for-doc "/tmp/some-other-pdf-file.pdf" "SOME HEADING")
-                                       :to-be 162)
-                                      (message "----")
-                                      (message (buffer-string))
-                                      (message "---- %s" (length (buffer-string)))
-
-                                      )))
+                                       :to-be 162))))
                               )
 
 
@@ -69,14 +57,10 @@
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
                                    (lambda ()
-                                      (message "\n11 ----")
                                       (insert "!!")
-                                      (message (buffer-string))
-                                      (message "\n11 ----")
                                       (expect
                                        (org-noter--find-top-level-heading-for-document-path "/tmp/test.pdf")
-                                       :to-be 143)
-                                      (message (buffer-string)))))
+                                       :to-be 143))))
 
 
                               (it "return nil for a non existent top level heading"
@@ -85,8 +69,7 @@
                                    (lambda ()
                                       (expect
                                        (org-noter--find-top-level-heading-for-document-path "/FAKE/PATH/DOESNT/EXIST")
-                                       :to-be nil)
-                                      (message (buffer-string)))))
+                                       :to-be nil))))
                               )
 
 

--- a/tests/org-noter-org-roam-tests.el
+++ b/tests/org-noter-org-roam-tests.el
@@ -1,3 +1,5 @@
+;;; -*- lexical-binding: t; -*-
+
 (require 'org-noter-test-utils)
 (require 'org-noter-org-roam)
 
@@ -15,7 +17,7 @@
                               (it "can insert a top level heading at the end of the file"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (org-noter--create-notes-heading "ADOCUMENT" "/tmp/file")
                                       (expect (string-match "ADOCUMENT" (buffer-string))  :not :to-be nil)
                                       (expect (string-match "/tmp/file" (buffer-string))  :not :to-be nil)
@@ -27,7 +29,7 @@
                               (it "can find an existing heading without creating a new one"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (let* ((found-heading-pos (org-noter--find-create-top-level-heading-for-doc "/tmp/test.pdf" "solove-nothing-to-hide")))
                                       (message "\n00 ----")
                                       (goto-char found-heading-pos)
@@ -44,7 +46,7 @@
                               (it "can create a new heading"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (expect
                                        ;; org-noter-test-file is defined in test-utils.
                                        (org-noter--find-create-top-level-heading-for-doc "/tmp/some-other-pdf-file.pdf" "SOME HEADING")
@@ -66,7 +68,7 @@
                               (it "can find the top level headline for a specified document and return the position"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (message "\n11 ----")
                                       (insert "!!")
                                       (message (buffer-string))
@@ -80,7 +82,7 @@
                               (it "return nil for a non existent top level heading"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (expect
                                        (org-noter--find-top-level-heading-for-document-path "/FAKE/PATH/DOESNT/EXIST")
                                        :to-be nil)
@@ -106,7 +108,7 @@
                         (spy-on 'org-noter)
                         (with-mock-contents
                          mock-contents-simple-notes-file
-                         '(lambda ()
+                         (lambda ()
                             (write-region (point-min) (point-max) "/tmp/pubs/notes.org")))
                         (org-noter--create-session-from-document-file-supporting-org-roam nil "/tmp/pubs/solove-nothing-to-hide.pdf")
                         (expect 'org-noter :to-have-been-called))

--- a/tests/org-noter-pdf-tests.el
+++ b/tests/org-noter-pdf-tests.el
@@ -1,3 +1,5 @@
+;;; -*- lexical-binding: t; -*-
+
 (add-to-list 'load-path "modules")
 (require 'org-noter-test-utils)
 
@@ -32,7 +34,7 @@
                               (it "can take a precise note WITH a highlight appearing"
                                   (with-mock-contents
                                    mock-contents-simple-notes-file
-                                   '(lambda ()
+                                   (lambda ()
                                       (org-noter-core-test-create-session)
                                       (with-simulated-input "precise SPC note RET"
                                                             (org-noter-insert-precise-note))


### PR DESCRIPTION
## Problem

Buttercup is failing to run (see #85).


## Solution

Had to enable lexical binding. But then quoted lambas started failing, so I had to refactor that a bit. 

## Steps to Test

Run 
    
    cask exec buttercup -L .