### PR TITLE
Fix nov precise-info and highlights.

### DIFF
--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -1,8 +1,8 @@
 ;;; org-noter-nov.el --- Integration with Nov.el     -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2022  c1-g
+;; Copyright (C) 2022  c1-g, 2024  Myers Studio Ltd.
 
-;; Author: c1-g <char1iegordon@protonmail.com>
+;; Author: c1-g <char1iegordon@protonmail.com>, Rhea Myers <rhea@myers.studio>
 ;; Keywords: multimedia
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -88,7 +88,10 @@
 (defun org-noter-nov--get-precise-info (mode window)
   (when (eq mode 'nov-mode)
     (if (region-active-p)
-        (cons (mark) (point))
+        (let ((from (mark))
+              (to (point)))
+          ;; If mark was after point, make sure we reverse them.
+          (cons (min from to) (max from to)))
       (let ((event nil))
         (while (not (and (eq 'mouse-1 (car event))
                          (eq window (posn-window (event-start event)))))

--- a/other/org-noter-nov-overlay.el
+++ b/other/org-noter-nov-overlay.el
@@ -26,6 +26,7 @@
 (require 'org-noter)
 (require 'nov)
 (require 'seq)
+(require 'color)
 
 (defcustom org-noter-nov-overlay-color-property "NOTER_OVERLAY"
   "A property that specifies the overlay color for `org-noter-nov-make-ov'.")


### PR DESCRIPTION
## Problem

Nov highlighting wasn't working for me.

## Solution

I changed the code a tiny bit to address that.

## Checklist

- [ x] I checked the code to make sure that it works on my machine.
- [ x] I checked that the code works without my custom emacs config.

## Steps to Test

Use this repo and make sure to use other/*.el and require org-noter-nov-overlay.
```
(use-package org-noter
  :straight (:repo "rheaplex/org-noter"
                   :host github
                   :type git
                   :files ("*.el" "modules/*.el" "other/*.el"))
  :custom (org-noter-highlight-selected-text t)
  :config (require 'org-noter-nov-overlay))
```

1. Open an epub and start an org noter document.
2. Select some text in the epub.
3. Enter `M-i` . We require a precise location for highlighting.
4. The text should appear as a note, and be highlighted.
