### PR TITLE
[Issue-92] feat: catch errors on trying to load org-roam to make it truly optional

### DIFF
--- a/modules/org-noter-org-roam.el
+++ b/modules/org-noter-org-roam.el
@@ -24,7 +24,13 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'org-roam-node)
+
+;; since org-roam is an optional dependency, it is not required for general use
+(eval-when-compile
+  (condition-case nil
+      (require 'org-roam-node)
+    (error (message "`org-roam-node is not found. org-noter's org-roam support requires org-roam to be installed. Please install org-roam."))))
+
 
 
 (defun org-noter--get-nodes-with-noter-document-property (doc-path)


### PR DESCRIPTION
## Problem

See #92.

## Solution

Catch the error while trying to load org-roam.

## Checklist

- [x] I checked the code to make sure that it works on my machine.
- [ ] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test


