### PR TITLE
Semver part2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ current-version:
 # Target to bump the patch version
 bump-patch:
 	@NEW_VERSION=$$(svu patch); \
-	sed -i.bak -E "s/^;; Version:.*/;; Version: $$NEW_VERSION/" $(TARGET_FILE); \
+	NEW_EMACS_VERSION=$$(echo $$NEW_VERSION | sed 's/^v//'); \
+	sed -i.bak -E "s/^;; Version:.*/;; Version: $$NEW_EMACS_VERSION/" $(TARGET_FILE); \
 	echo "New Patch Version: $$NEW_VERSION"; \
 	git add $(TARGET_FILE); \
 	git commit -m "Bump patch version to $$NEW_VERSION"; \
@@ -44,7 +45,8 @@ bump-patch:
 # Target to bump the minor version
 bump-minor:
 	@NEW_VERSION=$$(svu minor); \
-	sed -i.bak -E "s/^;; Version:.*/;; Version: $$NEW_VERSION/" $(TARGET_FILE); \
+	NEW_EMACS_VERSION=$$(echo $$NEW_VERSION | sed 's/^v//'); \
+	sed -i.bak -E "s/^;; Version:.*/;; Version: $$NEW_EMACS_VERSION/" $(TARGET_FILE); \
 	echo "New Patch Version: $$NEW_VERSION"; \
 	git add $(TARGET_FILE); \
 	git commit -m "Bump minor version to $$NEW_VERSION"; \

--- a/org-noter.el
+++ b/org-noter.el
@@ -9,7 +9,7 @@
 ;; Homepage: https://github.com/org-noter/org-noter
 ;; Keywords: lisp pdf interleave annotate external sync notes documents org-mode
 ;; Package-Requires: ((emacs "24.4") (cl-lib "0.6") (org "9.4"))
-;; Version: v1.6.0
+;; Version: 1.6.1
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
## Problem

Resolving the bug shared here: https://github.com/org-noter/org-noter/pull/93#issuecomment-2354033667

`version-to-list` only expects digits in the version, but we include the `v`.

## Solution

Remove the `v` from version.

## Steps to Test

1. `make bump-patch`
2. Look at org-noter.el and verify that the `Version` field is correct.