### PR TITLE
feat: functions to navigating in document from notes

### DIFF
--- a/README.org
+++ b/README.org
@@ -141,6 +141,8 @@ The official repo for this package is https://github.com/org-noter/org-noter/tre
 
     - ~org-noter-{next,prev}-page-from-notes~ :: Navigate document without leaving the notes buffer
 
+    - ~org-noter-insert-note-from-notes~ :: Insert note from notes window
+
 *** new (PDFs only with the [[https://github.com/vedang/pdf-tools][pdftools]] package)
     - 2D precise notes :: ([[https://github.com/ahmed-shariff/org-noter][Ahmed Shariff]]) Location tooltip appears at start of
       selected text or point of click.

--- a/README.org
+++ b/README.org
@@ -139,6 +139,8 @@ The official repo for this package is https://github.com/org-noter/org-noter/tre
       sessions directly from ~dired~.  Opens all marked files or the file at
       point if none are marked.
 
+    - ~org-noter-{next,prev}-page-from-notes~ :: Navigate document without leaving the notes buffer
+
 *** new (PDFs only with the [[https://github.com/vedang/pdf-tools][pdftools]] package)
     - 2D precise notes :: ([[https://github.com/ahmed-shariff/org-noter][Ahmed Shariff]]) Location tooltip appears at start of
       selected text or point of click.

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -2567,7 +2567,7 @@ synchronization features."
   "Flip to the next page on document from notes buffer"
   (interactive)
   (org-noter--with-valid-session
-   (with-current-buffer (window-buffer (org-noter--get-doc-window))
+   (with-selected-window (org-noter--get-doc-window)
      (cl-case major-mode
               (pdf-view-mode (pdf-view-next-page-command))
               (doc-view-mode (doc-view-next-line-or-next-page))
@@ -2578,7 +2578,7 @@ synchronization features."
   "Flip to the previous page on document from notes buffer"
   (interactive)
   (org-noter--with-valid-session
-   (with-current-buffer (window-buffer (org-noter--get-doc-window))
+   (with-selected-window  (org-noter--get-doc-window)
      (cl-case major-mode
               (pdf-view-mode (pdf-view-previous-page-command))
               (doc-view-mode (doc-view-previous-line-or-previous-page))
@@ -2589,7 +2589,7 @@ synchronization features."
   "Insert a note at current page from notes buffer"
   (interactive)
   (org-noter--with-valid-session
-   (with-current-buffer (window-buffer (org-noter--get-doc-window))
+   (with-selected-window (org-noter--get-doc-window)
      (org-noter-insert-note))))
 
 (define-minor-mode org-noter-doc-mode

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -2563,6 +2563,28 @@ synchronization features."
   (advice-remove 'dired-rename-file 'org-noter--update-doc-rename-in-notes)
   (advice-remove 'dired-rename-file 'org-noter--update-notes-rename-in-notes))
 
+(defun org-noter-next-page-from-notes ()
+  "Flip to the next page on document from notes buffer"
+  (interactive)
+  (org-noter--with-valid-session
+   (with-current-buffer (window-buffer (org-noter--get-doc-window))
+     (cl-case major-mode
+              (pdf-view-mode (pdf-view-next-page-command))
+              (doc-view-mode (doc-view-next-line-or-next-page))
+              (djvu-read-mode (djvu-next-page 1))
+              (nov-mode (scroll-other-window)))))) ; nov-scroll-up does not work here
+
+(defun org-noter-prev-page-from-notes ()
+  "Flip to the previous page on document from notes buffer"
+  (interactive)
+  (org-noter--with-valid-session
+   (with-current-buffer (window-buffer (org-noter--get-doc-window))
+     (cl-case major-mode
+              (pdf-view-mode (pdf-view-previous-page-command))
+              (doc-view-mode (doc-view-previous-line-or-previous-page))
+              (djvu-read-mode (djvu-prev-page 1))
+              (nov-mode (scroll-other-window-down)))))) ; nov-scroll-down does not work here
+
 (define-minor-mode org-noter-doc-mode
   "Minor mode for the document buffer.
 Keymap:

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -2572,7 +2572,7 @@ synchronization features."
               (pdf-view-mode (pdf-view-next-page-command))
               (doc-view-mode (doc-view-next-line-or-next-page))
               (djvu-read-mode (djvu-next-page 1))
-              (nov-mode (scroll-other-window)))))) ; nov-scroll-up does not work here
+              (nov-mode (nov-scroll-up nil))))))
 
 (defun org-noter-prev-page-from-notes ()
   "Flip to the previous page on document from notes buffer"
@@ -2583,7 +2583,7 @@ synchronization features."
               (pdf-view-mode (pdf-view-previous-page-command))
               (doc-view-mode (doc-view-previous-line-or-previous-page))
               (djvu-read-mode (djvu-prev-page 1))
-              (nov-mode (scroll-other-window-down)))))) ; nov-scroll-down does not work here
+              (nov-mode (nov-scroll-down nil))))))
 
 (defun org-noter-insert-note-from-notes ()
   "Insert a note at current page from notes buffer"

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -2585,6 +2585,13 @@ synchronization features."
               (djvu-read-mode (djvu-prev-page 1))
               (nov-mode (scroll-other-window-down)))))) ; nov-scroll-down does not work here
 
+(defun org-noter-insert-note-from-notes ()
+  "Insert a note at current page from notes buffer"
+  (interactive)
+  (org-noter--with-valid-session
+   (with-current-buffer (window-buffer (org-noter--get-doc-window))
+     (org-noter-insert-note))))
+
 (define-minor-mode org-noter-doc-mode
   "Minor mode for the document buffer.
 Keymap:


### PR DESCRIPTION
## Problem
Allow navigating and inserting note in document from notes window.

Fix #106

Maybe there should be default keybinds. I'm using M-n, M-p, and M-i, but I'm not sure they are appropriate as defaults as they override default commands.

## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [ ] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

I tested it for pdfview, djvu, docview, and nov.el. ~~Unfortunately I cannot get the nov.el version to also change chapters since scrolling doesn't really work from another buffer.~~ This works now.

## Steps to Test
Open an org-noter buffer and run the commands `org-noter-next-page-from-notes`, `org-noter-prev-page-from-notes`, and `org-noter-insert-note-from-notes`



