### PR TITLE
org-noter-nov--create-skeleton-epub: support EPUB3 ToC

### DIFF
--- a/modules/org-noter-nov.el
+++ b/modules/org-noter-nov.el
@@ -191,7 +191,7 @@
                                        (nov-url-filename-and-target url))
                                 (when (not (integerp nov-documents-index))
                                   (setq nov-documents-index 0))
-                                (list nov-documents-index (point)))))
+                                (cons nov-documents-index (point)))))
                (push (vector title location relative-level) output-data)))
            (push (vector "Skeleton" (list 0) 1) output-data)
 


### PR DESCRIPTION
## Problem

`org-noter` doesn't support creating a skeleton from a [EPUB 3.0 navigation document](https://www.w3.org/TR/epub-33/#sec-nav).


## Solution

This adds support for creating a skeleton from EPUB3 table of contents to
`org-noter-nov--create-skeleton-epub`. As a test, I ran through it some samples from the
[EPUB 3 Samples Project](https://idpf.github.io/epub3-samples/30/feature-matrix.html#Navigation_Document):
[Shared Culture](https://idpf.github.io/epub3-samples/30/samples.html#cc-shared-culture), [Children's Literature](https://idpf.github.io/epub3-samples/30/samples.html#childrens-literature), [The Waste Land](https://idpf.github.io/epub3-samples/30/samples.html#wasteland).

## Checklist

- [x] I checked the code to make sure that it works on my machine.
- [x] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test

1. Open a `org-noter` session with a EPUB3 `NOTER_DOCUMENT`.
2. Execute `org-noter-create-skeleton`.
3. Skeleton should be created in the notes buffer.
