### PR TITLE
Fix #115 (error with pdf-tools 1.3.0 and precise notes)

### DIFF
--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -141,7 +141,7 @@ original pretty-print function."
   (when (eq mode 'pdf-view-mode)
     (let (v-position h-position)
       (if (pdf-view-active-region-p)
-          (let ((edges (car (pdf-view-active-region))))
+          (let ((edges (cadr (pdf-view-active-region))))
             (setq v-position (min (nth 1 edges) (nth 3 edges))
                   h-position (min (nth 0 edges) (nth 2 edges))))
 


### PR DESCRIPTION
## Problem

Following the latest 1.3.0 `pdf-tools` update, the precise note feature became broken (see #115).

So, it closes #115.


## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [X] I checked that the code works without my custom emacs config.
- [x] I checked that the updated code works with the new `pdf-view-roll-minor-mode` feature that was introduced in version 1.3.0 `pdf-tools`