### PR TITLE
Feat: add the ability to prepend/append text to the default title using a token

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -86,8 +86,16 @@ at the moment."
 
 (defcustom org-noter-insert-note-replacement-token "##"
   "The token used in `org-noter-insert-note' to represent the default title.
+
 When entering a note title, occurrences of this token will be replaced by
-the default title (i.e., either the selected text or `org-noter-default-heading-title')."
+the default title (i.e., either the selected text or `org-noter-default-heading-title').
+
+Certain default behaviours should be noted:
+- If the text is short (as determined by `org-noter-max-short-selected-text-length') and a
+  replacement token is used, then the short text will NOT be added to note body. This can be
+  modified by setting `org-noter-insert-body-when-token-used' to non-nil.
+- Long text is added to note body regardless of whether a replacement token is used. This can be
+  modified by setting `org-noter-insert-long-text-inside-note' to nil."
   :group 'org-noter-insertion
   :type 'string)
 

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -2277,8 +2277,13 @@ Guiding principles for note generation
            (setq collection (nreverse collection)
                  ;; prompt for title (unless no-Q's)
                  title (if org-noter-insert-note-no-questions default-title
-                         (completing-read "Note: " collection nil nil nil nil default-title))
-                 note-body (if (and selected-text-p
+                         (completing-read "Note: " collection nil nil nil nil default-title)))
+           ;; "###" is a token to represent the selected text
+           (let ((token "###"))
+             (when (string-match-p (regexp-quote token) title)
+               (setq title (replace-regexp-in-string (regexp-quote token) default-title title t t))))
+
+           (setq note-body (if (and selected-text-p
                                     (not (equal title short-selected-text)))
                                selected-text)
                  ;; is this an existing note? skip for precise notes

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -91,14 +91,24 @@ the default title (i.e., either the selected text or `org-noter-default-heading-
   :group 'org-noter-insertion
   :type 'string)
 
-(defcustom org-noter-insert-body-when-token-used t
+(defcustom org-noter-insert-body-when-token-used nil
   "Control whether selected text is inserted in the body when used in the title.
 When the replacement token (see `org-noter-insert-note-replacement-token') is used in
 the note title, the selected text is substituted into the title.
 
-If non-nil (default), the selected text is inserted in the body even
-if the token was used.  If set to nil, the selected text is NOT
-repeated in the note body (preventing the text insertion)."
+If nil (default), the selected text is NOT repeated in the note body (preventing the
+text insertion).  If non-nil, the selected text is inserted in the body even
+if the token was used."
+  :group 'org-noter-insertion
+  :type 'boolean)
+
+(defcustom org-noter-insert-long-text-inside-note t
+  "Whether to insert selected text into the note body when it is considered 'long'.
+
+Text is considered 'long' if it exceeds `org-noter-max-short-selected-text-length'. 
+If non-nil (default), long text is inserted regardless of whether a
+`org-noter-insert-note-replacement-token' was used in the title (see
+`org-noter-insert-body-when-token-used')."
   :group 'org-noter-insertion
   :type 'boolean)
 
@@ -2306,8 +2316,12 @@ Guiding principles for note generation
 
            (setq note-body (if (and selected-text-p
                                     (not (equal title short-selected-text))
-                                    ;; only set note-body if token wasn't used... OR if user explicitly wants it
-                                    (or (not token-used) org-noter-insert-body-when-token-used))
+                                    (if short-selected-text
+                                        ;; what text is short: Only insert if token wasn't used, OR user explicitly allows it
+                                        (or (not token-used) org-noter-insert-body-when-token-used)
+                                      ;; If text is longer than the value of `org-noter-max-short-selected-text-length', then
+                                      ;; ignore token logic, use specific long-text variable
+                                      org-noter-insert-long-text-inside-note))
                                selected-text)
                  ;; is this an existing note? skip for precise notes
                  existing-note (unless precise-info (cdr (assoc title collection))))

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -92,31 +92,29 @@ the default title (i.e., either the selected text or `org-noter-default-heading-
 
 Certain default behaviours should be noted:
 - If the text is short (as determined by `org-noter-max-short-selected-text-length') and a
-  replacement token is used, then the short text will NOT be added to note body. This can be
-  modified by setting `org-noter-insert-body-when-token-used' to non-nil.
+  replacement token is used, then the short text will be repeated in the note body. This can be
+  modified by setting `org-noter-insert-short-text-inside-note'.
 - Long text is added to note body regardless of whether a replacement token is used. This can be
   modified by setting `org-noter-insert-long-text-inside-note' to nil."
   :group 'org-noter-insertion
   :type 'string)
 
-(defcustom org-noter-insert-body-when-token-used nil
-  "Control whether selected text is inserted in the body when used in the title.
-When the replacement token (see `org-noter-insert-note-replacement-token') is used in
-the note title, the selected text is substituted into the title.
+(defcustom org-noter-insert-short-text-inside-note t
+  "Control whether short text is inserted in the body when using `org-noter-insert-note-replacement-token'.
 
-If nil (default), the selected text is NOT repeated in the note body (preventing the
-text insertion).  If non-nil, the selected text is inserted in the body even
-if the token was used."
+If non-nil (default), the selected text is inserted in the body even
+if the token was used. If nil, the selected text is NOT repeated in the
+note body."
   :group 'org-noter-insertion
   :type 'boolean)
 
 (defcustom org-noter-insert-long-text-inside-note t
-  "Whether to insert selected text into the note body when it is considered 'long'.
+  "Control whether to insert 'long' selected text into the note body.
 
 Text is considered 'long' if it exceeds `org-noter-max-short-selected-text-length'. 
 If non-nil (default), long text is inserted regardless of whether a
 `org-noter-insert-note-replacement-token' was used in the title (see
-`org-noter-insert-body-when-token-used')."
+`org-noter-insert-short-text-inside-note')."
   :group 'org-noter-insertion
   :type 'boolean)
 
@@ -2326,7 +2324,7 @@ Guiding principles for note generation
                                     (not (equal title short-selected-text))
                                     (if short-selected-text
                                         ;; what text is short: Only insert if token wasn't used, OR user explicitly allows it
-                                        (or (not token-used) org-noter-insert-body-when-token-used)
+                                        (or (not token-used) org-noter-insert-short-text-inside-note)
                                       ;; If text is longer than the value of `org-noter-max-short-selected-text-length', then
                                       ;; ignore token logic, use specific long-text variable
                                       org-noter-insert-long-text-inside-note))

--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -2323,10 +2323,12 @@ Guiding principles for note generation
            (setq note-body (if (and selected-text-p
                                     (not (equal title short-selected-text))
                                     (if short-selected-text
-                                        ;; what text is short: Only insert if token wasn't used, OR user explicitly allows it
+                                        ;; if a replacement token is used and `org-noter-insert-short-text-inside-note' is non-nil
+                                        ;; the selected text is inserted in the note body.
                                         (or (not token-used) org-noter-insert-short-text-inside-note)
-                                      ;; If text is longer than the value of `org-noter-max-short-selected-text-length', then
-                                      ;; ignore token logic, use specific long-text variable
+                                      ;; if a replacement token is used and the
+                                      ;; text is longer than the value of `org-noter-max-short-selected-text-length', then
+                                      ;; use specific long-text variable to decide whether the highlighted text should be inserted
                                       org-noter-insert-long-text-inside-note))
                                selected-text)
                  ;; is this an existing note? skip for precise notes


### PR DESCRIPTION
## Feature
Hi!

Recently I noticed that I was manually prepending various notes with the text "Research idea: " over and over.

This feature would allow the user prepend or append text to the default title by using a token (can be customised by changing the value of `org-noter-insert-note-replacement-token`).


## How it works
1. Let's say I highlighted the text "Salivary gland tumour"
2. Press `i` or `M-i` to insert a note
3. In the minibuffer, you can write something like "Research idea: ##"
4. The output would be:
```
* Research idea: Salivary gland tumour
:PROPERTIES:
:NOTER_PAGE: 108
:END:

``Salivary gland tumour''
```

## Default behaviour
The insertion behaviour of the ``text'' can be modified (see `org-noter-insert-note-body-behavior`).

By default, if a replacement token is used, then the highlighted text will be repeated in the note body (as it is considered to be different).

## Use cases
Useful if you:
- have a system of tagging headings with a specific piece of text
  - either by prepending the text, or by using the default org-mode tagging system. Works for either!
- want to insert extra content to the highlighted text

No hard feelings if this is not desired :)


Harvey

## Checks
- [X] I have tested the feature fairly well, and seems to have no issues.
- [X] I checked the code to make sure that it works on my machine.
- [X] I checked that the code works without my custom emacs config.