### PR TITLE
Fix #122: `org-noter--note-after-tipping-point` fails when `closest-tipping-point` is `nil`

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -1469,10 +1469,10 @@ document property) will be opened."
                                                           point location view))
       (cdr hook-result))
      ((eq (aref view 0) 'paged)
-      (> (org-noter--get-location-top location) point))
+      (and point (> (org-noter--get-location-top location) point)))
      ((eq (aref view 0) 'nov)
-      (> (org-noter--get-location-top location) (+ (* point (- (cdr (aref view 2)) (cdr (aref view 1))))
-                                                   (cdr (aref view 1))))))))
+      (and point (> (org-noter--get-location-top location) (+ (* point (- (cdr (aref view 2)) (cdr (aref view 1))))
+                                                   (cdr (aref view 1)))))))))
 
 (defun org-noter--relative-position-to-view (location view)
   (cond


### PR DESCRIPTION
Hi

This will fix #122 

Made it so that we check things one by one and stop if we find a nil.

Seems to work well without issues.


## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [X] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.


Harvey R.