### PR TITLE
Fix #124: Pressing `M-i` without highlighting gives `wrong-type-argument` error

### DIFF
--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -141,15 +141,7 @@ original pretty-print function."
   (when (eq mode 'pdf-view-mode)
     (let (v-position h-position)
       (if (and (pdf-view-active-region-p)
-               ;; Guard to ensure the edges are actually populated. This is
-               ;; to prevent an error which happens if the user triggers
-               ;; ~org-noter-insert-precise-note~ without highlighting anything
-               (let ((edges (cadr (pdf-view-active-region))))
-                 (and edges
-                      (nth 0 edges)
-                      (nth 1 edges)
-                      (nth 2 edges)
-                      (nth 3 edges))))
+	       (cadr (pdf-view-active-region))) ; ensure the edges are ACTUALLY populated (needed for pdf-tools v1.3.0)
           (let ((edges (cadr (pdf-view-active-region))))
             (setq v-position (min (nth 1 edges) (nth 3 edges))
                   h-position (min (nth 0 edges) (nth 2 edges))))

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -140,18 +140,29 @@ original pretty-print function."
 (defun org-noter-pdf--pdf-view-get-precise-info (mode window)
   (when (eq mode 'pdf-view-mode)
     (let (v-position h-position)
-      (if (pdf-view-active-region-p)
+      (if (and (pdf-view-active-region-p)
+               ;; Guard to ensure the edges are actually populated. This is
+               ;; to prevent an error which happens if the user triggers
+               ;; ~org-noter-insert-precise-note~ without highlighting anything
+               (let ((edges (cadr (pdf-view-active-region))))
+                 (and edges
+                      (nth 0 edges)
+                      (nth 1 edges)
+                      (nth 2 edges)
+                      (nth 3 edges))))
           (let ((edges (cadr (pdf-view-active-region))))
             (setq v-position (min (nth 1 edges) (nth 3 edges))
                   h-position (min (nth 0 edges) (nth 2 edges))))
 
+        ;; fallback
         (let ((event nil))
           (while (not (and (eq 'mouse-1 (car event))
                            (eq window (posn-window (event-start event)))))
             (setq event (read-event "Click where you want the start of the note to be!")))
           (let* ((col-row (posn-col-row (event-start event)))
-                 (click-position (org-noter--conv-page-scroll-percentage (+ (window-vscroll) (cdr col-row))
-                                                                         (+ (window-hscroll) (car col-row)))))
+                 (click-position (org-noter--conv-page-scroll-percentage
+                                  (+ (window-vscroll) (cdr col-row))
+                                  (+ (window-hscroll) (car col-row)))))
             (setq v-position (car click-position)
                   h-position (cdr click-position)))))
       (cons v-position h-position))))


### PR DESCRIPTION
Hi

This will fix #124

Basically it validates region edges aren't nil before calling `min`

## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [X] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## New bahaviour
Now, when you click anywhere on the page and do not highlight anything and then press `M-i`, you get prompted to click somewhere on that page in order to create a precise note.


Harvey R.