### PR TITLE
 Feat: add screenshot extraction feature

### DIFF
--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -37,6 +37,34 @@
 (push "pdf" org-noter--doc-extensions)
 (cl-defstruct pdf-highlight page coords)
 
+(defcustom org-noter-pdf-screenshot-insert-style 'heading
+  "How to insert the screenshot link in the notes buffer.
+
+When set to `heading', a new Org heading is created via
+`org-noter-insert-note' and the file link is placed beneath it.
+
+When set to `link', the file link is inserted directly at point
+in the notes buffer with no preceding heading."
+  :type '(choice (const :tag "Insert under a new Org heading" heading)
+                 (const :tag "Insert as a plain link at point" link))
+  :group 'org-noter)
+
+(defcustom org-noter-pdf-screenshot-directory "org-noter-screenshots/"
+  "Default subdirectory (relative to the notes file) for saving PDF screenshots."
+  :type 'string
+  :group 'org-noter)
+
+(defcustom org-noter-pdf-screenshot-ask-before-save t
+  "Whether to prompt for a file path when saving a PDF screenshot.
+When non-nil (default), a `read-file-name' prompt is shown so
+the user can adjust the save location.
+
+When nil, the screenshot is saved directly to the default
+timestamped path under `org-noter-pdf-screenshot-directory'
+with no prompt."
+  :type 'boolean
+  :group 'org-noter)
+
 (defun org-noter-pdf--get-highlight ()
   "If there's an active pdf selection, returns a  that contains all
 the relevant info (page, coordinates)
@@ -477,6 +505,104 @@ v') for precise notes."
      dx dy)))
 
 (add-to-list 'org-noter--show-arrow-hook #'org-noter-pdf--show-arrow)
+
+(defun org-noter-pdf--generate-screenshot-path (notes-file-dir)
+  "Generate a default screenshot file path under NOTES-FILE-DIR."
+  (let* ((screenshot-dir (expand-file-name org-noter-pdf-screenshot-directory notes-file-dir))
+         (timestamp (format-time-string "%Y-%m-%d_%H%M%S"))
+         (filename (format "screenshot_%s.png" timestamp)))
+    (cons screenshot-dir (expand-file-name filename screenshot-dir))))
+
+(defun org-noter-pdf-save-screenshot ()
+  "Extract the active PDF region as an image, save it to disk, and
+insert an Org file link in the notes buffer.
+
+The user must first select a region in the PDF document buffer
+\(can be with either `pdf-view-set-region' or mouse selection\).
+
+By default the image is saved into an `org-noter-screenshots/'
+subdirectory next to the current notes file, with a timestamped
+filename.  When `org-noter-pdf-screenshot-ask-before-save' is
+non-nil a `read-file-name' prompt lets you adjust the path;
+otherwise the default path is used directly."
+  (interactive)
+  (org-noter--with-valid-session
+   (let* ((doc-buffer (org-noter--session-doc-buffer session))
+          (notes-buffer (org-noter--session-notes-buffer session))
+          (notes-file (buffer-file-name notes-buffer))
+          (notes-dir (if notes-file
+                         (file-name-directory notes-file)
+                       default-directory))
+          (default-path-pair (org-noter-pdf--generate-screenshot-path notes-dir))
+          (default-dir (car default-path-pair))
+          (default-file (cdr default-path-pair)))
+
+     ;; Validate pdf-view-active-region
+     (with-current-buffer doc-buffer
+       (unless (and (eq major-mode 'pdf-view-mode)
+                    (pdf-view-active-region-p))
+         (user-error "No active region in the PDF buffer.  Select a region first")))
+
+     (let* ((save-path (if org-noter-pdf-screenshot-ask-before-save
+                           (read-file-name "Save screenshot to: "
+                                           default-dir nil nil
+                                           (file-name-nondirectory default-file))
+                         default-file))
+            (save-dir (file-name-directory save-path)))
+
+       (make-directory save-dir t)
+
+       ;; extractions of img and saving to PC
+       (let ((temp-buffer (generate-new-buffer " *org-noter-screenshot*")))
+         (unwind-protect
+             (progn
+               (with-current-buffer doc-buffer
+                 (pdf-view-extract-region-image
+                  (pdf-view-active-region)
+                  (pdf-view-current-page)
+                  (pdf-view-image-size)
+                  temp-buffer
+                  t))
+               (with-current-buffer temp-buffer
+                 (let ((coding-system-for-write 'binary))
+                   (write-region (point-min) (point-max) save-path nil 'quiet)))
+               (with-current-buffer doc-buffer
+                 (pdf-view-deactivate-region)))
+           (when (buffer-live-p temp-buffer)
+             (kill-buffer temp-buffer))))
+
+       (let* ((relative-path (file-relative-name save-path notes-dir))
+              (link-text (format "[[file:%s]]" relative-path)))
+
+         (pcase org-noter-pdf-screenshot-insert-style
+           ('heading
+            ;; using `org-noter-insert-note' to create heading...
+            (let* ((location (org-noter--doc-approx-location 0))
+                   (page (car location))
+                   (title (format "Screenshot page %d" page))
+                   (org-noter-insert-note-no-questions t)
+                   (org-noter-default-heading-title title)
+                   ;; Prevent it from trying to use selected text as title!
+                   (org-noter-get-selected-text-hook nil)
+                   ;; We don't want to highlight anything as this will
+		   ;; be confusing
+		   ;; (see: https://github.com/org-noter/org-noter/pull/118)
+                   (org-noter-highlight-selected-text nil))
+
+              (org-noter-insert-note)
+
+              (with-current-buffer notes-buffer
+                (org-end-of-meta-data t)
+                (insert link-text "\n")
+                (org-show-set-visibility t)
+                (org-cycle-hide-drawers 'all))))
+
+           ('link
+            (with-current-buffer notes-buffer
+              (save-excursion
+                (insert link-text "\n")))))
+
+         (message "Saved screenshot to %s and inserted link." relative-path))))))
 
 (defun org-noter-pdf-set-columns (num-columns)
   "Interactively set the COLUMN_EDGES property for the current heading.

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -579,14 +579,16 @@ otherwise the default path is used directly."
             ;; using `org-noter-insert-note' to create heading...
             (let* ((location (org-noter--doc-approx-location 0))
                    (page (car location))
-                   (title (format "Screenshot page %d" page))
+                   (initial-input (format "Screenshot page %d" page))
+                   ;; Prompt user with pre-filled text they can edit
+                   (title (read-string "Note title: " initial-input))
                    (org-noter-insert-note-no-questions t)
                    (org-noter-default-heading-title title)
                    ;; Prevent it from trying to use selected text as title!
                    (org-noter-get-selected-text-hook nil)
-                   ;; We don't want to highlight anything as this will
-		   ;; be confusing
-		   ;; (see: https://github.com/org-noter/org-noter/pull/118)
+                   ;; NOTE(hnvy): We don't want to highlight
+                   ;; anything as this will be confusing
+                   ;; (see: https://github.com/org-noter/org-noter/pull/118)
                    (org-noter-highlight-selected-text nil))
 
               (org-noter-insert-note)

--- a/modules/org-noter-pdf.el
+++ b/modules/org-noter-pdf.el
@@ -574,6 +574,12 @@ otherwise the default path is used directly."
        (let* ((relative-path (file-relative-name save-path notes-dir))
               (link-text (format "[[file:%s]]" relative-path)))
 
+         ;; NOTE(hnvy): useful to push to `org-stored-links' for later
+	     ;; use (should the user need it for other uses).
+         (push (list (format "file:%s" relative-path)
+                     (file-name-nondirectory relative-path))
+               org-stored-links)
+
          (pcase org-noter-pdf-screenshot-insert-style
            ('heading
             ;; using `org-noter-insert-note' to create heading...
@@ -588,7 +594,6 @@ otherwise the default path is used directly."
                    (org-noter-get-selected-text-hook nil)
                    ;; NOTE(hnvy): We don't want to highlight
                    ;; anything as this will be confusing
-                   ;; (see: https://github.com/org-noter/org-noter/pull/118)
                    (org-noter-highlight-selected-text nil))
 
               (org-noter-insert-note)


### PR DESCRIPTION
## Problem

This PR adds the ability to select a PDF region and automatically save it as an image in the notes file. Insertion of image can either be:
- As heading with link
- As inline link

Previously, this required 4 manual and horrendouly laborious steps: selecting a region, extracting the image, navigating to save it, and inserting a link.

Merging it will close #110

Three customisable vars:
1. `org-noter-pdf-screenshot-insert-style` ==> controls whether the screenshot link is inserted under a new Org heading (`heading`) or as a plain inline link (`link`) at point
2. `org-noter-pdf-screenshot-directory` ==> set default save screenshots subdirectory
3. `org-noter-pdf-screenshot-ask-before-save` ==> when `t` (default), prompts for a save path. When nil, saves silently to the timestamped path...

## Checklist

- [X] I checked the code to make sure that it works on my machine.
- [X] I checked that the code works without my custom emacs config.
- [ ] I added unit tests.

## Steps to Test
1. In the PDF buffer, select a region using mouse drag (so that pdf-view-active-region-p returns non-nil)
4. Run M-x org-noter-pdf-save-screenshot
5. See how a read-file-name prompt appears with a default timestamped path under org-noter-screenshots/
6. Press Enter
7. Look at your notes file, and you should see:
   - Org link `[[file:org-noter-screenshots/screenshot_TIMESTAMP.png]]` is inserted (with a heading)
   - The PNG file is saved to the chosen location
8. temp buffer cleaned!

## Potential changes
- Should the user have control over what the link description should be? Or should it defualt to no desc?

## Here is a video

I hope you like it!

https://github.com/user-attachments/assets/00068d54-f32a-480f-8181-b5b2c9c7bf16

