### PR TITLE
Make org-noter-always-create-frame honest about nil

### DIFF
--- a/org-noter-core.el
+++ b/org-noter-core.el
@@ -145,12 +145,25 @@ notes that are not annotating the current page."
   :type 'boolean)
 
 (defcustom org-noter-always-create-frame t
-  "Create a new frame for each document session.
-When non-nil, org-noter will always create a new frame for the
-session.  When nil, it will use the selected frame if it does not
-belong to any other session."
+  "Whether to open each document session in its own frame.
+
+Possible values:
+
+- t              Always create a new, maximized frame for the
+                 session.  This is the default.
+
+- nil            Never create a new frame: reuse the selected frame,
+                 setting up the document and notes windows within it,
+                 even when it already hosts another session.
+
+- `reuse-if-free'  Reuse the selected frame only when it does not
+                 already belong to another org-noter session;
+                 otherwise create a new frame.  This was the
+                 historical behavior of the nil setting."
   :group 'org-noter
-  :type 'boolean)
+  :type '(choice (const :tag "Always create a new frame" t)
+                 (const :tag "Always reuse the selected frame" nil)
+                 (const :tag "Reuse the selected frame only if free" reuse-if-free)))
 
 (defcustom org-noter-disable-narrowing nil
   "Disable narrowing in notes/org buffer."
@@ -693,11 +706,16 @@ Otherwise return the maximum value for point."
            :id (org-noter--get-new-id)
            :display-name display-name
            :frame
-           (if (or org-noter-always-create-frame
-                   (catch 'has-session
-                     (dolist (test-session org-noter--sessions)
-                       (when (eq (org-noter--session-frame test-session) (selected-frame))
-                         (throw 'has-session t)))))
+           (if (pcase org-noter-always-create-frame
+                 ('reuse-if-free
+                  ;; Historical nil behavior: reuse the selected frame
+                  ;; unless it already belongs to another session.
+                  (catch 'has-session
+                    (dolist (test-session org-noter--sessions)
+                      (when (eq (org-noter--session-frame test-session) (selected-frame))
+                        (throw 'has-session t)))))
+                 ;; t means always create; nil means always reuse.
+                 (create-new-frame create-new-frame))
                (make-frame `((name . ,frame-name) (fullscreen . maximized)))
              (set-frame-parameter nil 'name frame-name)
              (selected-frame))

--- a/org-noter.el
+++ b/org-noter.el
@@ -83,7 +83,9 @@ even if the current heading annotates one.
 
 With a prefix number ARG:
 - Greater than 0: Open the document like `find-file'
--     Equal to 0: Create session with `org-noter-always-create-frame' toggled
+-     Equal to 0: Create session with the frame preference inverted:
+                  reuse the selected frame if `org-noter-always-create-frame'
+                  is t, otherwise force a new frame
 -    Less than 0: Open the folder containing the document
 
 - Creating the session from the document
@@ -110,7 +112,10 @@ notes file, even if it finds one."
                                (equal arg '(16))))
            (org-noter-always-create-frame
             (if (and (numberp arg) (= arg 0))
-                (not org-noter-always-create-frame)
+                ;; Invert the frame outcome for this session: t (always
+                ;; create) becomes nil (always reuse), while nil and
+                ;; `reuse-if-free' force a new frame.
+                (if (eq org-noter-always-create-frame t) nil t)
               org-noter-always-create-frame))
            (ast (org-noter--parse-root (vector (current-buffer) document-property)))
            (session-id (get-text-property (org-element-property :begin ast) org-noter--id-text-property))

--- a/tests/org-noter-frame-tests.el
+++ b/tests/org-noter-frame-tests.el
@@ -1,0 +1,101 @@
+;;; -*- lexical-binding: t; -*-
+;;
+;; Tests for the three-value `org-noter-always-create-frame' contract added
+;; in "Make org-noter-always-create-frame honest about nil".
+;;
+;; The frame decision lives inline in `org-noter--create-session'.  We never
+;; want a spec to really pop a GUI frame under batch Emacs, so `make-frame' is
+;; spied out and made to return the (live) selected frame.  That keeps every
+;; session valid while letting us assert on *whether* a new frame was
+;; requested for each value of the setting:
+;;
+;;   t              -> always create a new frame
+;;   nil            -> always reuse the selected frame (even if busy)
+;;   reuse-if-free  -> reuse the selected frame only when it is free,
+;;                     otherwise create a new frame (the old nil behavior)
+
+(add-to-list 'load-path "modules")
+(require 'with-simulated-input)
+(load-file "org-noter-test-utils.el")
+
+
+(describe "org-noter-always-create-frame"
+          (before-each
+           (create-org-noter-test-session)
+           ;; Stand in a real, live frame so `make-frame' never touches a
+           ;; window system, yet the resulting session stays valid.
+           (spy-on 'make-frame :and-return-value (selected-frame)))
+
+          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+          (describe "the customization contract"
+                    (it "defaults to always creating a frame"
+                        ;; Read the customize standard value rather than the
+                        ;; live value, which the test harness sets to nil.
+                        (expect (eval (car (get 'org-noter-always-create-frame
+                                                'standard-value))
+                                      t)
+                                :to-be t))
+
+                    (it "offers reuse-if-free as an explicit choice"
+                        (expect (flatten-tree
+                                 (get 'org-noter-always-create-frame 'custom-type))
+                                :to-contain 'reuse-if-free)))
+
+          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+          (describe "t"
+                    (it "always creates a new frame, even when the selected frame is free"
+                        (with-mock-contents
+                         mock-contents-simple-notes-file-with-a-single-note
+                         (lambda ()
+                           (setq org-noter-always-create-frame t)
+                           (let ((org-noter--sessions nil))
+                             (org-noter-core-test-create-session)
+                             (expect 'make-frame :to-have-been-called))))))
+
+          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+          (describe "nil"
+                    ;; This is the behavior the commit fixes: nil used to spawn
+                    ;; a new frame whenever the selected frame already hosted a
+                    ;; session.  It must now reuse the selected frame regardless.
+                    (it "reuses the selected frame even when it already hosts another session"
+                        (with-mock-contents
+                         mock-contents-simple-notes-file-with-a-single-note
+                         (lambda ()
+                           (setq org-noter-always-create-frame nil)
+                           ;; Pretend the selected frame is already busy with a
+                           ;; stand-in session.  `:id' must be a number so
+                           ;; `org-noter--get-new-id' can compare against it.
+                           (let ((org-noter--sessions
+                                  (list (make-org-noter--session
+                                         :id 0 :frame (selected-frame)))))
+                             (org-noter-core-test-create-session)
+                             (expect 'make-frame :not :to-have-been-called)
+                             (expect (org-noter--session-frame org-noter--session)
+                                     :to-be (selected-frame)))))))
+
+          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+          (describe "reuse-if-free"
+                    (it "reuses the selected frame when no session lives on it"
+                        (with-mock-contents
+                         mock-contents-simple-notes-file-with-a-single-note
+                         (lambda ()
+                           (setq org-noter-always-create-frame 'reuse-if-free)
+                           (let ((org-noter--sessions nil))
+                             (org-noter-core-test-create-session)
+                             (expect 'make-frame :not :to-have-been-called)
+                             (expect (org-noter--session-frame org-noter--session)
+                                     :to-be (selected-frame))))))
+
+                    (it "creates a new frame when the selected frame already hosts a session"
+                        (with-mock-contents
+                         mock-contents-simple-notes-file-with-a-single-note
+                         (lambda ()
+                           (setq org-noter-always-create-frame 'reuse-if-free)
+                           ;; A stand-in session already owns the frame.  `:id'
+                           ;; must be a number so `org-noter--get-new-id' can
+                           ;; compare against it.
+                           (let ((org-noter--sessions
+                                  (list (make-org-noter--session
+                                         :id 0 :frame (selected-frame)))))
+                             (org-noter-core-test-create-session)
+                             (expect 'make-frame :to-have-been-called)))))))

--- a/tests/org-noter-frame-tests.el
+++ b/tests/org-noter-frame-tests.el
@@ -47,8 +47,8 @@
                         (with-mock-contents
                          mock-contents-simple-notes-file-with-a-single-note
                          (lambda ()
-                           (setq org-noter-always-create-frame t)
-                           (let ((org-noter--sessions nil))
+                           (let ((org-noter-always-create-frame t)
+                                 (org-noter--sessions nil))
                              (org-noter-core-test-create-session)
                              (expect 'make-frame :to-have-been-called))))))
 
@@ -61,11 +61,11 @@
                         (with-mock-contents
                          mock-contents-simple-notes-file-with-a-single-note
                          (lambda ()
-                           (setq org-noter-always-create-frame nil)
                            ;; Pretend the selected frame is already busy with a
                            ;; stand-in session.  `:id' must be a number so
                            ;; `org-noter--get-new-id' can compare against it.
-                           (let ((org-noter--sessions
+                           (let ((org-noter-always-create-frame nil)
+                                 (org-noter--sessions
                                   (list (make-org-noter--session
                                          :id 0 :frame (selected-frame)))))
                              (org-noter-core-test-create-session)
@@ -79,8 +79,8 @@
                         (with-mock-contents
                          mock-contents-simple-notes-file-with-a-single-note
                          (lambda ()
-                           (setq org-noter-always-create-frame 'reuse-if-free)
-                           (let ((org-noter--sessions nil))
+                           (let ((org-noter-always-create-frame 'reuse-if-free)
+                                 (org-noter--sessions nil))
                              (org-noter-core-test-create-session)
                              (expect 'make-frame :not :to-have-been-called)
                              (expect (org-noter--session-frame org-noter--session)
@@ -90,14 +90,16 @@
                         (with-mock-contents
                          mock-contents-simple-notes-file-with-a-single-note
                          (lambda ()
-                           (setq org-noter-always-create-frame 'reuse-if-free)
                            ;; A stand-in session already owns the frame.  `:id'
                            ;; must be a number so `org-noter--get-new-id' can
                            ;; compare against it.
-                           (let ((org-noter--sessions
+                           (let ((org-noter-always-create-frame 'reuse-if-free)
+                                 (org-noter--sessions
                                   (list (make-org-noter--session
                                          :id 0 :frame (selected-frame)))))
                              (org-noter-core-test-create-session)
+                             (expect 'make-frame :to-have-been-called))))))
+
           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
           (describe "the prefix-0 toggle in `org-noter'"
                     ;; C-u 0 M-x org-noter inverts the frame outcome for one

--- a/tests/org-noter-frame-tests.el
+++ b/tests/org-noter-frame-tests.el
@@ -98,4 +98,34 @@
                                   (list (make-org-noter--session
                                          :id 0 :frame (selected-frame)))))
                              (org-noter-core-test-create-session)
+          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+          (describe "the prefix-0 toggle in `org-noter'"
+                    ;; C-u 0 M-x org-noter inverts the frame outcome for one
+                    ;; session: t becomes nil (reuse the selected frame),
+                    ;; while nil and reuse-if-free force a new frame.
+                    (it "reuses the selected frame when the setting is t"
+                        (with-mock-contents
+                         mock-contents-simple-notes-file-with-a-single-note
+                         (lambda ()
+                           (let ((org-noter-always-create-frame t)
+                                 (org-noter--sessions nil))
+                             (org-noter 0)
+                             (expect 'make-frame :not :to-have-been-called)))))
+
+                    (it "forces a new frame when the setting is nil"
+                        (with-mock-contents
+                         mock-contents-simple-notes-file-with-a-single-note
+                         (lambda ()
+                           (let ((org-noter-always-create-frame nil)
+                                 (org-noter--sessions nil))
+                             (org-noter 0)
+                             (expect 'make-frame :to-have-been-called)))))
+
+                    (it "forces a new frame when the setting is reuse-if-free"
+                        (with-mock-contents
+                         mock-contents-simple-notes-file-with-a-single-note
+                         (lambda ()
+                           (let ((org-noter-always-create-frame 'reuse-if-free)
+                                 (org-noter--sessions nil))
+                             (org-noter 0)
                              (expect 'make-frame :to-have-been-called)))))))


### PR DESCRIPTION
The variable name promises a boolean "always create a frame", but nil
still spawned a new frame whenever the selected frame already hosted a
session (the `has-session' guard), so notetaking a second document
always popped a new frame.

Redefine it as a three-value choice:

- t              always create a new frame (unchanged default)
- nil            never create a frame; reuse the selected frame, even
                 when it already hosts another session
- reuse-if-free  reuse the selected frame only when it is free,
                 otherwise create a new frame (the old nil behavior,
                 preserved as an opt-in)

Session teardown already tolerates a shared frame: kill-session only
deletes the frame when other frames exist and
`org-noter-kill-frame-at-session-end' is set, otherwise it just clears
the windows and frame name.